### PR TITLE
[Feat][115] 사용자 상품 조회/검색 정보 저장 및 조회

### DIFF
--- a/auth/src/main/java/com/ll/user/service/UserServiceImpl.java
+++ b/auth/src/main/java/com/ll/user/service/UserServiceImpl.java
@@ -86,8 +86,8 @@ public class UserServiceImpl implements UserService {
                 .name(request.name())
                 .build());
 
-        //userEventProducer.sendDeposit(savedUser.getId(),savedUser.getCode());
-        //userEventProducer.sendCart(savedUser.getId(),savedUser.getCode());
+        userEventProducer.sendDeposit(savedUser.getId(),savedUser.getCode());
+        userEventProducer.sendCart(savedUser.getId(),savedUser.getCode());
         return savedUser;
     }
 }

--- a/gateway/src/main/java/com/ll/gateway/filter/TokenExtractionFilter.java
+++ b/gateway/src/main/java/com/ll/gateway/filter/TokenExtractionFilter.java
@@ -1,11 +1,8 @@
 package com.ll.gateway.filter;
 
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.gateway.exception.GatewayBaseException;
 import com.ll.gateway.exception.GatewayErrorCode;
-import com.ll.gateway.resopnse.GatewayBaseResponse;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -13,12 +10,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpCookie;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
-
-import java.util.Optional;
 
 @Component
 @Slf4j
@@ -27,7 +21,6 @@ public class TokenExtractionFilter extends AbstractGatewayFilterFactory<TokenExt
     @Value("${custom.jwt.secrets.app-key}")
     private String secretKey;
 
-    private final ObjectMapper om = new ObjectMapper();
 
     public static class Config {
     }
@@ -47,7 +40,7 @@ public class TokenExtractionFilter extends AbstractGatewayFilterFactory<TokenExt
             //올바른 토큰 값 형식이 아닐 때
             if (!isValidToken(token)) {
                 log.error("Token value is invalid!");
-                return Mono.error(new GatewayBaseException(GatewayErrorCode.UNAUTHORIZED));
+                return chain.filter(exchange);
             }
 
             Jws<Claims> claims = getClaims(token);

--- a/gateway/src/main/java/com/ll/gateway/filter/TokenExtractionFilter.java
+++ b/gateway/src/main/java/com/ll/gateway/filter/TokenExtractionFilter.java
@@ -1,0 +1,111 @@
+package com.ll.gateway.filter;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.gateway.exception.GatewayBaseException;
+import com.ll.gateway.exception.GatewayErrorCode;
+import com.ll.gateway.resopnse.GatewayBaseResponse;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class TokenExtractionFilter extends AbstractGatewayFilterFactory<TokenExtractionFilter.Config> {
+
+    @Value("${custom.jwt.secrets.app-key}")
+    private String secretKey;
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    public static class Config {
+    }
+
+    public TokenExtractionFilter() {
+        super(Config.class);
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+
+            ServerHttpRequest request = exchange.getRequest();
+
+            Optional<String> tokenOptional = resolveToken(request);
+
+            if (tokenOptional.isEmpty()) {
+                log.info("No token found. Skip token extraction.");
+                return chain.filter(exchange);
+            }
+
+            String token = tokenOptional.get();
+
+            if (!isValidToken(token)) {
+                log.info("Invalid or expired token. Skipping token extraction.");
+                return chain.filter(exchange);
+            }
+
+            Jws<Claims> claims = getClaims(token);
+            String userCode = claims.getPayload().get("userCode", String.class);
+            String role = claims.getPayload().get("role", String.class);
+
+            ServerHttpRequest mutatedRequest = request.mutate()
+                    .header("X-User-Code", userCode)
+                    .header("X-Role", role)
+                    .build();
+
+            log.info("Injected userCode={}, role={} into headers", userCode, role);
+
+            return chain.filter(exchange.mutate().request(mutatedRequest).build());
+        };
+    }
+
+
+    private Optional<String> resolveToken(ServerHttpRequest request) {
+
+        String bearerToken = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return Optional.of(bearerToken.substring(7));
+        }
+        return Optional.empty();
+    }
+
+    private boolean isValidToken(String token) {
+
+        try {
+            getClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            log.info("Access Token expired msg : {}", e.getMessage());
+        } catch (JwtException e) {
+            log.info("Invalid JWT Token was detected msg : {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims String is empty msg : {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("an error raised from validating token msg : {}", e.getMessage());
+        }
+        return false;
+    }
+
+    private Jws<Claims> getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseSignedClaims(token);
+    }
+
+}
+
+
+

--- a/gateway/src/main/java/com/ll/gateway/filter/TokenExtractionFilter.java
+++ b/gateway/src/main/java/com/ll/gateway/filter/TokenExtractionFilter.java
@@ -1,8 +1,5 @@
 package com.ll.gateway.filter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ll.gateway.exception.GatewayBaseException;
-import com.ll.gateway.exception.GatewayErrorCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +9,6 @@ import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFac
 import org.springframework.http.HttpCookie;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 @Component
 @Slf4j

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -101,7 +101,7 @@ spring:
                 - name: TokenAuthenticationFilter
             # User
             - id: user-route-protected
-              uri: http://localhost:8083
+              uri: http://localhost:8084
               predicates:
                 - Path=/api/users/**
                 - Method=POST, GET, PATCH, DELETE
@@ -110,7 +110,7 @@ spring:
               order: 2
 
             - id: user-route-public
-              uri: http://localhost:8083
+              uri: http://localhost:8084
               predicates:
                 - Path=/api/users
                 - Method=GET

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -49,6 +49,8 @@ spring:
                 - Path=/api/products/**
                 - Method=GET
               order: 2
+              filters:
+                - name: TokenExtractionFilter
 
 
             - id: product-route-protected     #상품 수정 및 삭제 인증
@@ -64,6 +66,8 @@ spring:
               predicates:
                 - Path=/api/search/**
                 - Method=GET
+              filters:
+                - name: TokenExtractionFilter
 
             - id: product-images-route-protected   #이미지 업로드 인증
               uri: http://localhost:8085

--- a/products/build.gradle
+++ b/products/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     // env 파일 읽기
     implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 
+    // redis 관련 implementation
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 }

--- a/products/src/main/java/com/ll/products/ProductsApplication.java
+++ b/products/src/main/java/com/ll/products/ProductsApplication.java
@@ -4,8 +4,10 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class ProductsApplication {
     public static void main(String[] args) {

--- a/products/src/main/java/com/ll/products/config/RedisConfig.java
+++ b/products/src/main/java/com/ll/products/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.ll.auth.config;
+package com.ll.products.config;
 
 
 import org.springframework.context.annotation.Bean;

--- a/products/src/main/java/com/ll/products/domain/history/config/ProcedureInitializer.java
+++ b/products/src/main/java/com/ll/products/domain/history/config/ProcedureInitializer.java
@@ -1,0 +1,82 @@
+package com.ll.products.domain.history.config;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProcedureInitializer {
+
+    private final DataSource dataSource;
+
+    @PostConstruct
+    public void init() {
+        createViewHistoryProcedure();
+        createSearchHistoryProcedure();
+    }
+
+    private void createViewHistoryProcedure() {
+        String dropSql = "DROP PROCEDURE IF EXISTS clean_view_history";
+
+        String createSql = """
+            CREATE PROCEDURE clean_view_history()
+            BEGIN
+                DECLARE cutoff_id BIGINT DEFAULT NULL;
+
+                SELECT id INTO cutoff_id
+                FROM view_history
+                ORDER BY id DESC
+                LIMIT 1 OFFSET 49999;
+
+                IF cutoff_id IS NOT NULL THEN
+                    DELETE FROM view_history WHERE id < cutoff_id;
+                END IF;
+            END
+            """;
+
+        executeProcedure("clean_view_history", dropSql, createSql);
+    }
+
+    private void createSearchHistoryProcedure() {
+        String dropSql = "DROP PROCEDURE IF EXISTS clean_search_history";
+
+        String createSql = """
+            CREATE PROCEDURE clean_search_history()
+            BEGIN
+                DECLARE cutoff_id BIGINT DEFAULT NULL;
+
+                SELECT id INTO cutoff_id
+                FROM search_history
+                ORDER BY id DESC
+                LIMIT 1 OFFSET 49999;
+
+                IF cutoff_id IS NOT NULL THEN
+                    DELETE FROM search_history WHERE id < cutoff_id;
+                END IF;
+            END
+            """;
+
+        executeProcedure("clean_search_history", dropSql, createSql);
+    }
+
+    private void executeProcedure(String name, String dropSql, String createSql) {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+
+            stmt.execute(dropSql);
+            stmt.execute(createSql);
+
+            log.info("{} 프로시저 자동 생성 완료", name);
+
+        } catch (Exception e) {
+            log.warn("{} 프로시저 생성 실패: {}", name, e.getMessage());
+        }
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/history/controller/HistoryController.java
+++ b/products/src/main/java/com/ll/products/domain/history/controller/HistoryController.java
@@ -1,0 +1,33 @@
+package com.ll.products.domain.history.controller;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.history.service.HistoryFacadeService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("api/history")
+public class HistoryController {
+
+    HistoryFacadeService historyFacadeService;
+    @GetMapping("recentview")
+    public ResponseEntity<BaseResponse<List<String>>> getRecentView(
+            @RequestHeader("X-User-Code") String userCode
+    ){
+        return BaseResponse.ok(historyFacadeService.getViewList(userCode));
+    }
+
+    @GetMapping("recentsearch")
+    public ResponseEntity<BaseResponse<List<String>>> getRecentSearch(
+            @RequestHeader("X-User-Code") String userCode
+    ){
+        return BaseResponse.ok(historyFacadeService.getSearchList(userCode));
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/history/entity/SearchHistory.java
+++ b/products/src/main/java/com/ll/products/domain/history/entity/SearchHistory.java
@@ -1,0 +1,37 @@
+package com.ll.products.domain.history.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class SearchHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String userCode;
+
+    @Column(nullable = false)
+    private String keyWord;
+
+    @Column(nullable =false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public SearchHistory(String userCode,String keyWord){
+        this.userCode=userCode;
+        this.keyWord=keyWord;
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/history/entity/SearchHistory.java
+++ b/products/src/main/java/com/ll/products/domain/history/entity/SearchHistory.java
@@ -2,7 +2,6 @@ package com.ll.products.domain.history.entity;
 
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;

--- a/products/src/main/java/com/ll/products/domain/history/entity/ViewHistory.java
+++ b/products/src/main/java/com/ll/products/domain/history/entity/ViewHistory.java
@@ -1,0 +1,37 @@
+package com.ll.products.domain.history.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class ViewHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String userCode;
+
+    @Column(nullable = false)
+    private String productCode;
+
+    @Column(nullable =false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public ViewHistory(String userCode,String productCode){
+        this.userCode=userCode;
+        this.productCode=productCode;
+    }
+
+}

--- a/products/src/main/java/com/ll/products/domain/history/repository/HistoryProcedureRepository.java
+++ b/products/src/main/java/com/ll/products/domain/history/repository/HistoryProcedureRepository.java
@@ -3,6 +3,7 @@ package com.ll.products.domain.history.repository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -10,10 +11,12 @@ public class HistoryProcedureRepository {
 
     private final EntityManager em;
 
+    @Transactional
     public void cleanViewHistory() {
         em.createNativeQuery("CALL clean_view_history()").executeUpdate();
     }
 
+    @Transactional
     public void cleanSearchHistory() {
         em.createNativeQuery("CALL clean_search_history()").executeUpdate();
     }

--- a/products/src/main/java/com/ll/products/domain/history/repository/HistoryProcedureRepository.java
+++ b/products/src/main/java/com/ll/products/domain/history/repository/HistoryProcedureRepository.java
@@ -1,0 +1,20 @@
+package com.ll.products.domain.history.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HistoryProcedureRepository {
+
+    private final EntityManager em;
+
+    public void cleanViewHistory() {
+        em.createNativeQuery("CALL clean_view_history()").executeUpdate();
+    }
+
+    public void cleanSearchHistory() {
+        em.createNativeQuery("CALL clean_search_history()").executeUpdate();
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/history/repository/SearchHistoryRepository.java
+++ b/products/src/main/java/com/ll/products/domain/history/repository/SearchHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.ll.products.domain.history.repository;
+
+import com.ll.products.domain.history.entity.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory,Long> {
+    List<SearchHistory> findTop30ByUserCodeOrderByCreatedAtDesc(String userCode);
+}

--- a/products/src/main/java/com/ll/products/domain/history/repository/ViewHistoryRepository.java
+++ b/products/src/main/java/com/ll/products/domain/history/repository/ViewHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.ll.products.domain.history.repository;
+
+import com.ll.products.domain.history.entity.ViewHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ViewHistoryRepository extends JpaRepository<ViewHistory,Long> {
+    List<ViewHistory> findTop30ByUserCodeOrderByCreatedAtDesc(String userCode);
+}

--- a/products/src/main/java/com/ll/products/domain/history/service/HistoryCleanupScheduler.java
+++ b/products/src/main/java/com/ll/products/domain/history/service/HistoryCleanupScheduler.java
@@ -1,0 +1,28 @@
+package com.ll.products.domain.history.service;
+
+import com.ll.products.domain.history.repository.HistoryProcedureRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HistoryCleanupScheduler {
+
+    private final HistoryProcedureRepository historyProcedureRepository;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+    public void cleanViewHistory() {
+        historyProcedureRepository.cleanViewHistory();
+        log.info("[스케줄러] ViewHistory 정리 완료");
+    }
+
+    @Scheduled(cron = "0 10 3 * * *") // 3시 10분
+    public void cleanSearchHistory() {
+        historyProcedureRepository.cleanSearchHistory();
+        log.info("[스케줄러] SearchHistory 정리 완료");
+    }
+}
+

--- a/products/src/main/java/com/ll/products/domain/history/service/HistoryFacadeService.java
+++ b/products/src/main/java/com/ll/products/domain/history/service/HistoryFacadeService.java
@@ -1,0 +1,85 @@
+package com.ll.products.domain.history.service;
+
+import com.ll.products.domain.history.entity.SearchHistory;
+import com.ll.products.domain.history.entity.ViewHistory;
+import com.ll.products.global.util.RedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HistoryFacadeService {
+
+    private final RedisService redisService;
+    private final HistoryService historyService;
+
+    public void saveSearch(String userCode, String keyword) {
+        try {
+            redisService.pushSearchData(userCode, keyword);
+        } catch (Exception e) {
+            log.error("Redis Server Down in SaveSearch");
+        } finally {
+            historyService.saveSearchHistory(userCode, keyword);
+        }
+    }
+
+    public void saveView(String userCode, String productCode) {
+        try {
+            redisService.pushViewData(userCode, productCode);
+        } catch (Exception e) {
+            log.error("Redis Server Down in SaveView");
+        } finally {
+            historyService.saveViewHistory(userCode, productCode);
+        }
+    }
+
+    public List<String> getSearchList(String userCode) {
+        try {
+            List<String> keywords = redisService.getSearchData(userCode);
+            if (keywords == null || keywords.isEmpty()) {
+                keywords = historyService.getSearchHistory(userCode)
+                        .stream()
+                        .map(SearchHistory::getKeyWord)
+                        .toList();
+
+                keywords.forEach(keyword -> redisService.pushSearchData(userCode, keyword));
+            }
+            return keywords;
+        } catch (Exception e) {
+            log.error("Redis Server Down in GetSearchList");
+
+            return historyService.getSearchHistory(userCode)
+                    .stream()
+                    .map(SearchHistory::getKeyWord)
+                    .toList();
+        }
+    }
+
+    public List<String> getViewList(String userCode) {
+
+        try {
+            List<String> products = redisService.getViewData(userCode);
+
+            if (products == null || products.isEmpty()) {
+                products = historyService.getViewHistory(userCode)
+                        .stream()
+                        .map(ViewHistory::getProductCode)
+                        .toList();
+                products.forEach(productCode -> redisService.pushViewData(userCode, productCode));
+            }
+            return products;
+
+        } catch (Exception e) {
+            log.error("Redis Server Down in GetViewList");
+
+            return historyService.getViewHistory(userCode)
+                    .stream()
+                    .map(ViewHistory::getProductCode)
+                    .toList();
+        }
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/history/service/HistoryService.java
+++ b/products/src/main/java/com/ll/products/domain/history/service/HistoryService.java
@@ -1,0 +1,34 @@
+package com.ll.products.domain.history.service;
+
+import com.ll.products.domain.history.entity.SearchHistory;
+import com.ll.products.domain.history.entity.ViewHistory;
+import com.ll.products.domain.history.repository.SearchHistoryRepository;
+import com.ll.products.domain.history.repository.ViewHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final SearchHistoryRepository searchHistoryRepository;
+    private final ViewHistoryRepository viewHistoryRepository;
+
+    public void saveSearchHistory(String userCode, String keyword) {
+        searchHistoryRepository.save(new SearchHistory(userCode, keyword));
+    }
+
+    public void saveViewHistory(String userCode, String productCode) {
+        viewHistoryRepository.save(new ViewHistory(userCode, productCode));
+    }
+
+    public List<SearchHistory> getSearchHistory(String userCode) {
+        return searchHistoryRepository.findTop30ByUserCodeOrderByCreatedAtDesc(userCode);
+    }
+
+    public List<ViewHistory> getViewHistory(String userCode) {
+        return viewHistoryRepository.findTop30ByUserCodeOrderByCreatedAtDesc(userCode);
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
@@ -1,8 +1,8 @@
 package com.ll.products.domain.product.controller;
 
 import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.history.service.HistoryFacadeService;
 import com.ll.products.domain.product.model.dto.request.ProductUpdateInventoryRequest;
-import com.ll.products.global.util.RedisService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,7 @@ public class ProductController {
     // 결제/후처리는 비동기 가능 -> 사용자 경험 개선 ( 오래 걸림 )
 
     private final ProductService productService;
-    private final RedisService redisService;
+    private final HistoryFacadeService historyFacadeService;
 
     // 1. 상품 생성
     @PostMapping
@@ -50,12 +50,12 @@ public class ProductController {
     public ResponseEntity<BaseResponse<ProductResponse>> getProduct(
             @PathVariable String code,
             @RequestHeader(value = "X-User-Code",required = false) String userCode) {
-        if(userCode != null){
-            redisService.saveViewData(userCode,code);
-            log.info("getProduct Controller 접근 usercode: {}",userCode);
 
-        }
         ProductResponse response = productService.getProduct(code);
+        if(userCode != null){
+            historyFacadeService.saveView(userCode,code);
+            log.info("getProduct Controller 접근 usercode: {}",userCode);
+        }
         return BaseResponse.ok(response);
     }
 
@@ -124,7 +124,7 @@ public class ProductController {
             @RequestHeader("X-User-Code") String userCode
     ){
         log.info("recentView Controller 접근 usercode: {}",userCode);
-        return BaseResponse.ok(redisService.getViewData(userCode));
+        return BaseResponse.ok(historyFacadeService.getViewList(userCode));
     }
 
     @GetMapping("recentsearch")
@@ -132,6 +132,6 @@ public class ProductController {
             @RequestHeader("X-User-Code") String userCode
     ){
         log.info("recentSearch Controller 접근 usercode: {}",userCode);
-        return BaseResponse.ok(redisService.getSearchData(userCode));
+        return BaseResponse.ok(historyFacadeService.getSearchList(userCode));
     }
 }

--- a/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
@@ -118,20 +118,4 @@ public class ProductController {
         productService.updateInventory(code, request.quantity());
         return BaseResponse.ok(null);
     }
-
-    @GetMapping("recentview")
-    public ResponseEntity<BaseResponse<List<String>>> getRecentView(
-            @RequestHeader("X-User-Code") String userCode
-    ){
-        log.info("recentView Controller 접근 usercode: {}",userCode);
-        return BaseResponse.ok(historyFacadeService.getViewList(userCode));
-    }
-
-    @GetMapping("recentsearch")
-    public ResponseEntity<BaseResponse<List<String>>> getRecentSearch(
-            @RequestHeader("X-User-Code") String userCode
-    ){
-        log.info("recentSearch Controller 접근 usercode: {}",userCode);
-        return BaseResponse.ok(historyFacadeService.getSearchList(userCode));
-    }
 }

--- a/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import com.ll.products.domain.product.model.dto.request.ProductUpdateInventoryRe
 import com.ll.products.global.util.RedisService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,6 +20,9 @@ import com.ll.products.domain.product.model.dto.response.ProductResponse;
 import com.ll.products.domain.product.model.entity.ProductStatus;
 import com.ll.products.domain.product.service.ProductService;
 
+import java.util.List;
+
+@Slf4j
 @RestController
 @RequestMapping("/api/products")
 @RequiredArgsConstructor
@@ -48,6 +52,8 @@ public class ProductController {
             @RequestHeader(value = "X-User-Code",required = false) String userCode) {
         if(userCode != null){
             redisService.saveViewData(userCode,code);
+            log.info("getProduct Controller 접근 usercode: {}",userCode);
+
         }
         ProductResponse response = productService.getProduct(code);
         return BaseResponse.ok(response);
@@ -111,5 +117,21 @@ public class ProductController {
     ) {
         productService.updateInventory(code, request.quantity());
         return BaseResponse.ok(null);
+    }
+
+    @GetMapping("recentview")
+    public ResponseEntity<BaseResponse<List<String>>> getRecentView(
+            @RequestHeader("X-User-Code") String userCode
+    ){
+        log.info("recentView Controller 접근 usercode: {}",userCode);
+        return BaseResponse.ok(redisService.getViewData(userCode));
+    }
+
+    @GetMapping("recentsearch")
+    public ResponseEntity<BaseResponse<List<String>>> getRecentSearch(
+            @RequestHeader("X-User-Code") String userCode
+    ){
+        log.info("recentSearch Controller 접근 usercode: {}",userCode);
+        return BaseResponse.ok(redisService.getSearchData(userCode));
     }
 }

--- a/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.ll.products.domain.product.controller;
 
 import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.product.model.dto.request.ProductUpdateInventoryRequest;
+import com.ll.products.global.util.RedisService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,6 +28,7 @@ public class ProductController {
     // 결제/후처리는 비동기 가능 -> 사용자 경험 개선 ( 오래 걸림 )
 
     private final ProductService productService;
+    private final RedisService redisService;
 
     // 1. 상품 생성
     @PostMapping
@@ -41,7 +43,12 @@ public class ProductController {
 
     // 2. 상품 상세조회
     @GetMapping("/{code}")
-    public ResponseEntity<BaseResponse<ProductResponse>> getProduct(@PathVariable String code) {
+    public ResponseEntity<BaseResponse<ProductResponse>> getProduct(
+            @PathVariable String code,
+            @RequestHeader(value = "X-User-Code",required = false) String userCode) {
+        if(userCode != null){
+            redisService.saveViewData(userCode,code);
+        }
         ProductResponse response = productService.getProduct(code);
         return BaseResponse.ok(response);
     }

--- a/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
+++ b/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
@@ -1,8 +1,8 @@
 package com.ll.products.domain.search.controller;
 import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.history.service.HistoryFacadeService;
 import com.ll.products.domain.search.dto.ProductSearchResponse;
 import com.ll.products.domain.search.service.ProductSearchService;
-import com.ll.products.global.util.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class ProductSearchController {
 
     private final ProductSearchService productSearchService;
-    private final RedisService redisService;
+    private final HistoryFacadeService historyFacadeService;
 
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<Page<ProductSearchResponse>>> search(
@@ -31,8 +31,7 @@ public class ProductSearchController {
             @PageableDefault(size = 20) Pageable pageable
     ) {
         if(userCode != null){
-            redisService.saveSearchData(userCode,keyword);
-            log.info("searchData Controller 접근 usercode: {}",userCode);
+            historyFacadeService.saveSearch(userCode,keyword);
         }
         log.debug("상품 검색 API 호출: keyword={}, categoryId={}, price={}-{}, status={}, pageable={}",
                 keyword, categoryId, minPrice, maxPrice, status, pageable);

--- a/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
+++ b/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
@@ -2,6 +2,7 @@ package com.ll.products.domain.search.controller;
 import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.search.dto.ProductSearchResponse;
 import com.ll.products.domain.search.service.ProductSearchService;
+import com.ll.products.global.util.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class ProductSearchController {
 
     private final ProductSearchService productSearchService;
+    private final RedisService redisService;
 
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<Page<ProductSearchResponse>>> search(
@@ -25,6 +27,7 @@ public class ProductSearchController {
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String status,
+            @RequestHeader(value = "X-User-Code",required = false ) String userCode,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         log.debug("상품 검색 API 호출: keyword={}, categoryId={}, price={}-{}, status={}, pageable={}",

--- a/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
+++ b/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
@@ -30,6 +30,10 @@ public class ProductSearchController {
             @RequestHeader(value = "X-User-Code",required = false ) String userCode,
             @PageableDefault(size = 20) Pageable pageable
     ) {
+        if(userCode != null){
+            redisService.saveSearchData(userCode,keyword);
+            log.info("searchData Controller 접근 usercode: {}",userCode);
+        }
         log.debug("상품 검색 API 호출: keyword={}, categoryId={}, price={}-{}, status={}, pageable={}",
                 keyword, categoryId, minPrice, maxPrice, status, pageable);
         Page<ProductSearchResponse> result = productSearchService.search(keyword, categoryId, minPrice, maxPrice, status, pageable);

--- a/products/src/main/java/com/ll/products/global/util/RedisService.java
+++ b/products/src/main/java/com/ll/products/global/util/RedisService.java
@@ -8,34 +8,45 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.List;
 
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisService {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final Long TTL = 15L;
-    private final Long dataRange = 30L;
+    private final Long TTL = 15L;          // 데이터 유지기간 (일)
+    private final Long dataRange = 30L;    // 저장 최대 개수
 
     public void saveSearchData(String userCode, String keyword) {
         String key = generateSearchCode(userCode);
-        redisTemplate.opsForList().leftPush(key,keyword);
-        redisTemplate.expire(key, Duration.ofDays(TTL));
+        try {
+            redisTemplate.opsForList().leftPush(key, keyword);
+            redisTemplate.opsForList().trim(key, 0, dataRange - 1); // 최대 개수 유지
+            redisTemplate.expire(key, Duration.ofDays(TTL));
+            log.info("Redis 검색 기록 저장 성공 :{}",keyword);
+        } catch (Exception e) {
+            log.warn("Redis 검색 기록 저장 실패: {}", e.getMessage());
+        }
     }
 
     public void saveViewData(String userCode, String productCode) {
         String key = generateViewCode(userCode);
-        redisTemplate.opsForList().leftPush(key,productCode);
-        redisTemplate.expire(key, Duration.ofDays(TTL));
+        try {
+            redisTemplate.opsForList().leftPush(key, productCode);
+            redisTemplate.opsForList().trim(key, 0, dataRange - 1); // 최대 개수 유지
+            redisTemplate.expire(key, Duration.ofDays(TTL));
+            log.info("Redis 조회 기록 저장 성공 :{}", productCode);
+        } catch (Exception e) {
+            log.warn("Redis 조회 기록 저장 실패: {}", e.getMessage());
+        }
     }
 
     public List<String> getSearchData(String userCode){
-        return redisTemplate.opsForList().range(generateSearchCode(userCode),0,dataRange);
+        return redisTemplate.opsForList().range(generateSearchCode(userCode), 0, dataRange - 1);
     }
 
     public List<String> getViewData(String userCode){
-        return redisTemplate.opsForList().range(generateViewCode(userCode),0,dataRange);
+        return redisTemplate.opsForList().range(generateViewCode(userCode), 0, dataRange - 1);
     }
 
     private String generateSearchCode(String userCode){
@@ -46,4 +57,3 @@ public class RedisService {
         return "view:" + userCode;
     }
 }
-

--- a/products/src/main/java/com/ll/products/global/util/RedisService.java
+++ b/products/src/main/java/com/ll/products/global/util/RedisService.java
@@ -1,0 +1,49 @@
+package com.ll.products.global.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final Long TTL = 15L;
+    private final Long dataRange = 30L;
+
+    public void saveSearchData(String userCode, String keyword) {
+        String key = generateSearchCode(userCode);
+        redisTemplate.opsForList().leftPush(key,keyword);
+        redisTemplate.expire(key, Duration.ofDays(TTL));
+    }
+
+    public void saveViewData(String userCode, String productCode) {
+        String key = generateViewCode(userCode);
+        redisTemplate.opsForList().leftPush(key,productCode);
+        redisTemplate.expire(key, Duration.ofDays(TTL));
+    }
+
+    public List<String> getSearchData(String userCode){
+        return redisTemplate.opsForList().range(generateSearchCode(userCode),0,dataRange);
+    }
+
+    public List<String> getViewData(String userCode){
+        return redisTemplate.opsForList().range(generateViewCode(userCode),0,dataRange);
+    }
+
+    private String generateSearchCode(String userCode){
+        return "search:" + userCode;
+    }
+
+    private String generateViewCode(String userCode){
+        return "view:" + userCode;
+    }
+}
+

--- a/products/src/main/resources/application-local.yml
+++ b/products/src/main/resources/application-local.yml
@@ -29,7 +29,11 @@ spring:
       group-id: product-service
       properties:
         allow.auto.create.topics: false
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 60000ms
 # 로깅 설정
 logging:
   level:

--- a/products/src/main/resources/application-local.yml
+++ b/products/src/main/resources/application-local.yml
@@ -20,7 +20,7 @@ spring:
 
   # Elasticsearch 설정
   elasticsearch:
-    uris: http://localhost:9202
+    uris: http://localhost:9200
 
   kafka:
     bootstrap-servers:

--- a/products/src/main/resources/application-local.yml
+++ b/products/src/main/resources/application-local.yml
@@ -33,7 +33,11 @@ spring:
     redis:
       host: localhost
       port: 6379
-      timeout: 60000ms
+      timeout: 500ms
+      lettuce:
+        pool:
+          max-active: 5
+        shutdown-timeout: 100ms
 # 로깅 설정
 logging:
   level:

--- a/products/src/main/resources/application.yml
+++ b/products/src/main/resources/application.yml
@@ -21,6 +21,9 @@ management:
       show-details: always                           # 헬스체크 상세 정보
     info:
       enabled: true
+  health:
+    redis:
+      enabled: false
   tracing:
     sampling:
       probability: 1.0


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 사용자가 상품을 조회/검색하는 정보를 저장 및 조회하는 기능 추가

🔗 관련 이슈
---
- 관련 이슈 번호: #115

📋 요구 사항과 구현 내용
---
- Gateway Filter 에서 AccessToken이 있을때만 Usercode를 추출 , 아니면 통과시키는 TokenExtractionFilter 추가
- 상품 검색 , 조회 Controller 에 X-User-Code 헤더 추가
- 상품 검색시 KeyWord , 조회시 ProductCode 를 Redis 및 DB 에 저장하는 로직
- 로그인한 유저의 최근 30개 데이터를 조회하는 로직
- 프로시저를 통한 데이터 개수 관리

💬 TODO 리스트
---


🧠 고려사항
---
- 고민한 점

- DB에 모든 검색/조회 데이터를 넣을 것인가?
  - 현재 기능에서 DB를 사용하는 이유는 Redis Only로 사용했을때 Redis 서버가 불안정하여 데이터가 손실될경우 데이터 복원을 위한 용도
  - 그래서 유저별 최근 30개 데이터를 조회하기위해 모든 검색/조회 데이터를 넣는것은 불가피
  - 하지만 데이터가 쌓일경우 DB를 조회하는 속도가 느려질것을 대비하여 5만개 초과되는 데이터를 삭제하는 프로시저를 추가
  - 스케줄러를 통해 요청이 적은 시간인 새벽3시에 해당 프로시저를 실행해 데이터 갯수 조절.

<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1) 히스토리(검색/조회) 도메인 추가 및 백엔드 로직
- 새 엔터티/리포지토리: SearchHistory, ViewHistory 및 관련 Repository 추가
- 서비스/컨트롤러/초기화: HistoryService, HistoryController, HistoryProcedureInitializer 등으로 저장·조회·스케줄(정리) 로직 구현
- 파일예: domain/history/* (여러 클래스 추가)

2) 게이트웨이에서 토큰 추출 필터 도입
- TokenExtractionFilter 클래스 추가: 쿠키에서 토큰을 꺼내 요청 헤더로 전파하고 유효성 검사
- application-local.yml에 TokenExtractionFilter 설정(필터 등록/경로) 추가
- 대상 파일: gateway/filter/TokenExtractionFilter.java, gateway 리소스 yml

3) Product/Search 연동 변경
- ProductSearchController(또는 유사 컨트롤러)에서 검색 시 HistoryService 호출해 검색 이력 저장
- ProductsApplication에 JPA Auditing·Scheduling 활성화(관련 애너테이션 추가)

4) Redis 설정 간소화/조정
- RedisConfig.java들에서 일부 key/hash serializer 설정 제거 또는 변경(모듈별로 적용)
- 영향 파일: auth/config/RedisConfig.java 등

5) 빌드·구성·의존성 변경
- gradle/애플리케이션 설정 업데이트(Products 애플리케이션 관련 의존성·설정 추가)
- Resources(예: application-local.yml)에 필터 및 엔드포인트 관련 설정 추가

6) 사용자 이벤트 발행 코드 소소 수정
- UserServiceImpl 변경: 이벤트 발행 로직(userEventProducer.sendDeposit 등) 정리 및 savedUser 반환 등 조정
- 파일: UserServiceImpl.java
<!-- AI-GENERATOR:END -->