### PR TITLE
[Feat][129] 상품 추천 API 구현

### DIFF
--- a/products/docker-compose-es.yml
+++ b/products/docker-compose-es.yml
@@ -47,49 +47,6 @@ services:
     volumes:
       - qdrant-data:/qdrant/storage
 
-  kafka:
-    image: apache/kafka:latest
-    container_name: products-kafka
-    ports:
-      - "9092:9092"
-    environment:
-      - KAFKA_NODE_ID=1
-      - KAFKA_PROCESS_ROLES=broker,controller
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,INTERNAL://0.0.0.0:9094
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092,INTERNAL://products-kafka:9094
-      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT
-      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@products-kafka:9093
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
-      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
-      - KAFKA_MIN_INSYNC_REPLICAS=1
-      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
-      - CLUSTER_ID=QszDYpiURRaeCz86lsxokg
-    volumes:
-      - kafka-data:/var/lib/kafka/data
-    healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"]
-      interval: 5s
-      timeout: 10s
-      retries: 10
-      start_period: 30s
-
-  kafka-init:
-    image: apache/kafka:latest
-    container_name: products-kafka-init
-    depends_on:
-      kafka:
-        condition: service_healthy
-    command: >
-      bash -c "
-        echo 'Creating Kafka topics...';
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server products-kafka:9094 --create --if-not-exists --topic product-events --partitions 3 --replication-factor 1;
-        echo 'Kafka topics created successfully';
-      "
-    restart: "no"
-
 volumes:
   qdrant-data:
   kafka-data:

--- a/products/docker-compose-es.yml
+++ b/products/docker-compose-es.yml
@@ -37,5 +37,59 @@ services:
       elasticsearch:
         condition: service_healthy
 
-#volumes:
-#  es-data:
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: products-qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant-data:/qdrant/storage
+
+  kafka:
+    image: apache/kafka:latest
+    container_name: products-kafka
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_NODE_ID=1
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,INTERNAL://0.0.0.0:9094
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092,INTERNAL://products-kafka:9094
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@products-kafka:9093
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_MIN_INSYNC_REPLICAS=1
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+      - CLUSTER_ID=QszDYpiURRaeCz86lsxokg
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  kafka-init:
+    image: apache/kafka:latest
+    container_name: products-kafka-init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    command: >
+      bash -c "
+        echo 'Creating Kafka topics...';
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server products-kafka:9094 --create --if-not-exists --topic product-events --partitions 3 --replication-factor 1;
+        echo 'Kafka topics created successfully';
+      "
+    restart: "no"
+
+volumes:
+  qdrant-data:
+  kafka-data:

--- a/products/src/main/java/com/ll/products/domain/recommendation/config/QdrantConfig.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/config/QdrantConfig.java
@@ -1,0 +1,46 @@
+package com.ll.products.domain.recommendation.config;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Slf4j
+@Configuration
+public class QdrantConfig {
+
+    @Value("${qdrant.host}")
+    private String host;
+
+    @Value("${qdrant.port}")
+    private int port;
+
+    @Value("${qdrant.collection-name}")
+    private String collectionName;
+
+
+    @Bean
+    public QdrantClient qdrantClient() {
+        log.info("Qdrant 클라이언트 초기화: {}:{}", host, port);
+        try {
+            return new QdrantClient(
+                    QdrantGrpcClient.newBuilder(host, port, false)
+                            .withTimeout(Duration.ofSeconds(10))
+                            .build()
+            );
+        } catch (Exception e) {
+            log.error("Qdrant 클라이언트 초기화 실패", e);
+            throw new IllegalStateException("Qdrant 연결 불가", e);
+        }
+    }
+
+    @Bean
+    public String qdrantCollectionName() {
+        return collectionName;
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/config/VectorDbIndexInitializer.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/config/VectorDbIndexInitializer.java
@@ -1,0 +1,33 @@
+package com.ll.products.domain.recommendation.config;
+
+import com.ll.products.domain.recommendation.service.RecommendationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!prod")
+@Order(99)
+@RequiredArgsConstructor
+public class VectorDbIndexInitializer implements ApplicationRunner {
+    private final RecommendationService recommendationService;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.debug("=== VectorDB 전체 재색인 시작 (백그라운드) ===");
+
+        try {
+            long startTime = System.currentTimeMillis();
+            recommendationService.reindexAllProducts();
+            long duration = System.currentTimeMillis() - startTime;
+            log.debug("=== VectorDB 전체 재색인 완료 (소요시간: {}ms) ===", duration);
+        } catch (Exception e) {
+            log.error("=== VectorDB 재색인 실패: {} ===", e.getMessage(), e);
+        }
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/RecommendationController.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,49 @@
+package com.ll.products.domain.recommendation.controller;
+
+import com.ll.products.domain.recommendation.dto.RecommendationResponse;
+import com.ll.products.domain.recommendation.service.RecommendationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/products/recommendations")
+@RequiredArgsConstructor
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+
+    // 1. 유사한 상품 추천
+    @GetMapping("/similar/{productCode}")
+    public ResponseEntity<List<RecommendationResponse>> getSimilarProducts(
+            @PathVariable String productCode,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        log.info("유사 상품 추천 요청: productCode={}, limit={}", productCode, limit);
+        List<RecommendationResponse> recommendations = recommendationService.recommendSimilarProducts(productCode, limit);
+        return ResponseEntity.ok(recommendations);
+    }
+
+    // 2. 검색어 기반 상품 추천
+    @GetMapping("/search")
+    public ResponseEntity<List<RecommendationResponse>> searchRecommendations(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        log.info("검색어 기반 추천 요청: keyword={}, limit={}", keyword, limit);
+        List<RecommendationResponse> recommendations = recommendationService.recommendProductsByKeyword(keyword, limit);
+        return ResponseEntity.ok(recommendations);
+    }
+
+    // 3. 전체 상품 재색인 (관리자용)
+    @PostMapping("/reindex")
+    public ResponseEntity<String> reindexAllProducts() {
+        log.info("전체 상품 재색인 요청");
+        recommendationService.reindexAllProducts();
+        return ResponseEntity.ok("전체 상품 재색인이 시작되었습니다.");
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/document/ProductVectorDocument.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/document/ProductVectorDocument.java
@@ -1,0 +1,61 @@
+package com.ll.products.domain.recommendation.document;
+
+import com.ll.products.domain.product.model.entity.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductVectorDocument {
+
+    private String productCode;
+    private String name;
+    private String description;
+    private String categoryName;
+    private Integer price;
+    private String status;
+
+    public static ProductVectorDocument from(Product product) {
+        return ProductVectorDocument.builder()
+                .productCode(product.getCode())
+                .name(product.getName())
+                .description(product.getDescription())
+                .categoryName(product.getCategory() != null ? product.getCategory().getName() : null)
+                .price(product.getPrice())
+                .status(product.getStatus().name())
+                .build();
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("productCode", productCode);
+        payload.put("name", name);
+        payload.put("description", description);
+        payload.put("categoryName", categoryName);
+        payload.put("price", price);
+        payload.put("status", status);
+        return payload;
+    }
+
+    public String generateEmbeddingText() {
+        StringBuilder text = new StringBuilder();
+        text.append("상품명: ").append(name).append(". ");
+        if (description != null && !description.isBlank()) {
+            text.append("설명: ").append(description).append(". ");
+        }
+        if (categoryName != null && !categoryName.isBlank()) {
+            text.append("카테고리: ").append(categoryName).append(". ");
+        }
+        if (price != null) {
+            text.append("가격: ").append(String.format("%,d원", price)).append(". ");
+        }
+        return text.toString();
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/document/ProductVectorPoint.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/document/ProductVectorPoint.java
@@ -1,0 +1,25 @@
+package com.ll.products.domain.recommendation.document;
+
+import lombok.Getter;
+
+@Getter
+public class ProductVectorPoint {
+
+    private final ProductVectorDocument document;
+    private final float[] embedding;
+
+    public static ProductVectorPoint of(ProductVectorDocument document, float[] embedding) {
+        return new ProductVectorPoint(document, embedding);
+    }
+
+    private ProductVectorPoint(ProductVectorDocument document, float[] embedding) {
+        if (document == null) {
+            throw new IllegalArgumentException("document는 null일 수 없습니다");
+        }
+        if (embedding == null || embedding.length == 0) {
+            throw new IllegalArgumentException("embedding은 null이거나 비어있을 수 없습니다");
+        }
+        this.document = document;
+        this.embedding = embedding;
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/dto/RecommendationResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/dto/RecommendationResponse.java
@@ -1,0 +1,15 @@
+package com.ll.products.domain.recommendation.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RecommendationResponse(
+        String productCode,
+        String name,
+        String description,
+        String categoryName,
+        Integer price,
+        String status,
+        Float score
+) {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/service/EmbeddingService.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/service/EmbeddingService.java
@@ -1,0 +1,89 @@
+package com.ll.products.domain.recommendation.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmbeddingService {
+
+    private final EmbeddingModel embeddingModel;
+
+    // 1. 임베딩(단일)
+    public float[] generateEmbedding(String text) {
+        String validatedText = validateText(text);
+        try {
+            log.debug("임베딩 생성 중");
+            EmbeddingResponse response = embeddingModel.embedForResponse(List.of(validatedText));
+            float[] embedding = validateEmbedding(response);
+            log.debug("임베딩 생성 완료");
+            return embedding;
+        } catch (Exception e) {
+            log.error("임베딩 생성 실패", e);
+            throw new RuntimeException("임베딩 생성 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+
+    // 2. 임베딩(다중)
+    public List<float[]> generateEmbeddings(List<String> texts) {
+        if (texts == null || texts.isEmpty()) {
+            log.warn("빈 텍스트 리스트로 임베딩 생성");
+            return List.of();
+        }
+        List<String> validatedTexts = texts.stream()
+                .map(this::validateText)
+                .toList();
+        try {
+            EmbeddingResponse response = embeddingModel.embedForResponse(validatedTexts);
+            List<float[]> embeddings = validateEmbeddings(response, validatedTexts.size());
+            log.info("배치 임베딩 생성 완료: count={}", embeddings.size());
+            return embeddings;
+        } catch (Exception e) {
+            throw new RuntimeException("배치 임베딩 생성 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+
+    // 텍스트 검증
+    private String validateText(String text) {
+        if (text == null || text.isBlank()) {
+            log.warn("빈 텍스트로 임베딩 생성");
+            return "empty";
+        }
+        return text;
+    }
+
+    // 임베딩 검증(단일)
+    private float[] validateEmbedding(EmbeddingResponse response) {
+        if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
+            throw new RuntimeException("임베딩 응답이 비어있습니다");
+        }
+
+        float[] embedding = response.getResults().get(0).getOutput();
+        if (embedding == null || embedding.length == 0) {
+            throw new RuntimeException("임베딩 벡터가 비어있습니다");
+        }
+        return embedding;
+    }
+
+
+    // 임베딩 검증(다중)
+    private List<float[]> validateEmbeddings(EmbeddingResponse response, int expectedCount) {
+        if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
+            throw new RuntimeException("임베딩 응답이 비어있습니다");
+        }
+        List<float[]> embeddings = response.getResults().stream()
+                .map(result -> result.getOutput())
+                .toList();
+
+        if (embeddings.size() != expectedCount) {
+            throw new RuntimeException("임베딩 개수가 일치하지 않습니다");
+        }
+        return embeddings;
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/service/RecommendationService.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/service/RecommendationService.java
@@ -1,0 +1,178 @@
+package com.ll.products.domain.recommendation.service;
+
+import com.ll.products.domain.product.exception.ProductNotFoundException;
+import com.ll.products.domain.product.model.entity.Product;
+import com.ll.products.domain.product.repository.ProductRepository;
+import com.ll.products.domain.recommendation.document.ProductVectorDocument;
+import com.ll.products.domain.recommendation.document.ProductVectorPoint;
+import com.ll.products.domain.recommendation.dto.RecommendationResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+
+    private final ProductRepository productRepository;
+    private final EmbeddingService embeddingService;
+    private final VectorStoreService vectorStoreService;
+
+    private static final int BATCH_SIZE = 50;
+
+    // 1. 유사 상품 추천
+    @Transactional(readOnly = true)
+    public List<RecommendationResponse> recommendSimilarProducts(String productCode, int limit) {
+        Product product = findProductByCode(productCode);
+        float[] embedding = generateProductEmbedding(product);
+        List<RecommendationResponse> recommendations = vectorStoreService.searchSimilarProducts(embedding, limit + 1);
+        return excludeSelfProduct(recommendations, productCode, limit);
+    }
+
+    // 2. 키워드 기반 상품 추천
+    public List<RecommendationResponse> recommendProductsByKeyword(String keyword, int limit) {
+        float[] embedding = embeddingService.generateEmbedding(keyword);
+        return vectorStoreService.searchSimilarProducts(embedding, limit);
+    }
+
+    // 3. 상품 인덱스 삭제
+    public void deleteProductIndex(String productCode) {
+        try {
+            vectorStoreService.deleteProductByCode(productCode);
+            log.info("상품 색인 삭제 완료: {}", productCode);
+        } catch (Exception e) {
+            log.error("상품 색인 삭제 실패: {}", productCode, e);
+        }
+    }
+
+
+
+
+    // 상품 인덱싱
+    public void indexProduct(Product product) {
+        try {
+            ProductVectorPoint vectorPoint = createVectorPoint(product);
+            vectorStoreService.upsertProduct(vectorPoint);
+            log.info("상품 색인 완료: {}", product.getCode());
+        } catch (Exception e) {
+            log.error("상품 색인 실패: {}", product.getCode(), e);
+        }
+    }
+
+    // 모든 상품 재색인
+    public void reindexAllProducts() {
+        vectorStoreService.recreateCollection();
+        List<Product> products = productRepository.findAllByIsDeletedFalse();
+        log.info("전체 상품 재색인 시작: 총 {}개", products.size());
+        if (products.isEmpty()) {
+            log.info("인덱싱할 상품이 없습니다.");
+            return;
+        }
+        IndexingResult result = indexBatchProducts(products);
+        log.info("전체 상품 재색인 완료: 성공 {}개, 실패 {}개", result.successCount, result.failCount);
+    }
+
+    // 상품 조회
+    private Product findProductByCode(String productCode) {
+        return productRepository.findByCodeAndIsDeletedFalse(productCode)
+                .orElseThrow(() -> new ProductNotFoundException(productCode));
+    }
+
+    // 상품 임베딩
+    private float[] generateProductEmbedding(Product product) {
+        ProductVectorDocument document = ProductVectorDocument.from(product);
+        String embeddingText = document.generateEmbeddingText();
+        return embeddingService.generateEmbedding(embeddingText);
+    }
+
+    // 벡터 point 생성
+    private ProductVectorPoint createVectorPoint(Product product) {
+        ProductVectorDocument document = ProductVectorDocument.from(product);
+        String embeddingText = document.generateEmbeddingText();
+        float[] embedding = embeddingService.generateEmbedding(embeddingText);
+        return ProductVectorPoint.of(document, embedding);
+    }
+
+    // 상품 리스트에서 본인 제외
+    private List<RecommendationResponse> excludeSelfProduct(
+            List<RecommendationResponse> recommendations,
+            String productCode,
+            int limit) {
+        return recommendations.stream()
+                .filter(rec -> !rec.productCode().equals(productCode))
+                .limit(limit)
+                .toList();
+    }
+
+    // 인덱싱(다중)
+    private IndexingResult indexBatchProducts(List<Product> products) {
+        int successCount = 0;
+        int failCount = 0;
+
+        for (int startIndex = 0; startIndex < products.size(); startIndex += BATCH_SIZE) {
+            int endIndex = Math.min(startIndex + BATCH_SIZE, products.size());
+            List<Product> batch = products.subList(startIndex, endIndex);
+            log.info("배치 처리 중: {}-{}/{}", startIndex + 1, endIndex, products.size());
+            try {
+                indexProducts(batch);
+                successCount += batch.size();
+                log.info("배치 처리 완료: {} 건", batch.size());
+            } catch (Exception e) {
+                log.error("배치 처리 실패: {}-{}", startIndex + 1, endIndex, e);
+                int[] fallbackResult = fallbackIndexing(batch);
+                successCount += fallbackResult[0];
+                failCount += fallbackResult[1];
+            }
+        }
+        return new IndexingResult(successCount, failCount);
+    }
+
+    // 상품 저장(다중)
+    private void indexProducts(List<Product> batch) {
+        // vectorDocument 생성
+        List<ProductVectorDocument> documents = batch.stream()
+                .map(ProductVectorDocument::from)
+                .toList();
+
+        // 임베딩 텍스트 생성
+        List<String> embeddingTexts = documents.stream()
+                .map(ProductVectorDocument::generateEmbeddingText)
+                .toList();
+
+        // 배치 임베딩 생성
+        List<float[]> embeddings = embeddingService.generateEmbeddings(embeddingTexts);
+
+        // point 리스트 생성
+        List<ProductVectorPoint> vectorPoints = IntStream.range(0, documents.size())
+                .mapToObj(i -> ProductVectorPoint.of(documents.get(i), embeddings.get(i)))
+                .toList();
+
+        // Qdrant에 배치 저장
+        vectorStoreService.upsertProducts(vectorPoints);
+    }
+
+    // 배치 실패 시 개별 인덱싱
+    private int[] fallbackIndexing(List<Product> batch) {
+        int success = 0;
+        int fail = 0;
+
+        for (Product product : batch) {
+            try {
+                indexProduct(product);
+                success++;
+            } catch (Exception e) {
+                log.error("상품 색인 실패: {}", product.getCode(), e);
+                fail++;
+            }
+        }
+        return new int[]{success, fail};
+    }
+
+    // 인덱싱 결과 record
+    private record IndexingResult(int successCount, int failCount) {}
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/service/VectorStoreService.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/service/VectorStoreService.java
@@ -1,0 +1,181 @@
+package com.ll.products.domain.recommendation.service;
+
+import com.ll.products.domain.recommendation.document.ProductVectorPoint;
+import com.ll.products.domain.recommendation.dto.RecommendationResponse;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.grpc.Collections.*;
+import io.qdrant.client.grpc.Points.*;
+import io.qdrant.client.grpc.JsonWithInt.Value;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.qdrant.client.ConditionFactory.*;
+import static io.qdrant.client.PointIdFactory.id;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.VectorsFactory.vectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VectorStoreService {
+
+    private final QdrantClient qdrantClient;
+    private final String qdrantCollectionName;
+
+    private static final int VECTOR_SIZE = 1536;
+
+    // 1. 상품 벡터 저장(단일)
+    public void upsertProduct(ProductVectorPoint productVectorPoint) {
+        try {
+            PointStruct point = buildPointStruct(productVectorPoint);
+            qdrantClient.upsertAsync(qdrantCollectionName, List.of(point)).get();
+            log.info("상품 벡터 저장 완료: productCode={}", productVectorPoint.getDocument().getProductCode());
+        } catch (Exception e) {
+            log.error("상품 벡터 저장 실패: productCode={}", productVectorPoint.getDocument().getProductCode(), e);
+            throw new RuntimeException("벡터 저장 중 오류 발생", e);
+        }
+    }
+
+    // 2. 상품 벡터 저장(다중)
+    public void upsertProducts(List<ProductVectorPoint> productVectorPoints) {
+        if (productVectorPoints == null || productVectorPoints.isEmpty()) {
+            log.warn("빈 상품 벡터 리스트로 저장 시도");
+            return;
+        }
+        try {
+            List<PointStruct> points = productVectorPoints.stream()
+                    .map(this::buildPointStruct)
+                    .toList();
+            qdrantClient.upsertAsync(qdrantCollectionName, points).get();
+            log.info("배치 상품 벡터 저장 완료: count={}", productVectorPoints.size());
+        } catch (Exception e) {
+            log.error("배치 상품 벡터 저장 실패: count={}", productVectorPoints.size(), e);
+            throw new RuntimeException("배치 벡터 저장 중 오류 발생", e);
+        }
+    }
+
+    // 3. 유사 상품 검색
+    public List<RecommendationResponse> searchSimilarProducts(float[] embedding, int limit) {
+        try {
+            List<ScoredPoint> scoredPoints = qdrantClient.searchAsync(
+                    SearchPoints.newBuilder()
+                            .setCollectionName(qdrantCollectionName)
+                            .addAllVector(convertToList(embedding))
+                            .setLimit(limit)
+                            .setWithPayload(WithPayloadSelector.newBuilder().setEnable(true).build())
+                            .build()
+            ).get();
+            List<RecommendationResponse> results = scoredPoints.stream()
+                    .map(this::convertToRecommendation)
+                    .toList();
+            log.info("유사 상품 검색 완료: 결과 개수={}", results.size());
+            return results;
+        } catch (Exception e) {
+            log.error("유사 상품 검색 실패", e);
+            throw new RuntimeException("벡터 검색 중 오류 발생", e);
+        }
+    }
+
+    // 4. 상품 코드로 삭제
+    public void deleteProductByCode(String productCode) {
+        try {
+            Filter filter = Filter.newBuilder()
+                    .addMust(matchKeyword("productCode", productCode))
+                    .build();
+
+            qdrantClient.deleteAsync(qdrantCollectionName, filter).get();
+            log.info("상품 벡터 삭제 완료: productCode={}", productCode);
+        } catch (Exception e) {
+            log.error("상품 벡터 삭제 실패: productCode={}", productCode, e);
+            throw new RuntimeException("벡터 삭제 중 오류 발생", e);
+        }
+    }
+
+    // 5. 컬렉션 삭제 후 재생성
+    public void recreateCollection() {
+        deleteCollection();
+        createCollection();
+    }
+
+
+
+
+    // 컬렉션 생성
+    private void createCollection() {
+        try {
+            log.info("Qdrant 컬렉션 생성 중: {}", qdrantCollectionName);
+            qdrantClient.createCollectionAsync(
+                    qdrantCollectionName,
+                    VectorParams.newBuilder()
+                            .setSize(VECTOR_SIZE)
+                            .setDistance(Distance.Cosine)
+                            .build()
+            ).get();
+            log.debug("Qdrant 컬렉션 생성 완료: {}", qdrantCollectionName);
+        } catch (Exception e) {
+            log.warn("Qdrant 컬렉션 생성 실패. 추천 기능은 사용할 수 없습니다.", e);
+        }
+    }
+
+    // 컬렉션 삭제
+    private void deleteCollection() {
+        try {
+            log.info("Qdrant 컬렉션 삭제 중: {}", qdrantCollectionName);
+            qdrantClient.deleteCollectionAsync(qdrantCollectionName).get();
+            log.info("Qdrant 컬렉션 삭제 완료: {}", qdrantCollectionName);
+        } catch (Exception e) {
+            log.warn("Qdrant 컬렉션 삭제 실패 (컬렉션이 없을 수 있음): {}", e.getMessage());
+        }
+    }
+
+    // pointStruct 생성
+    private PointStruct buildPointStruct(ProductVectorPoint vectorPoint) {
+        return PointStruct.newBuilder()
+                .setId(id(UUID.fromString(vectorPoint.getDocument().getProductCode())))
+                .setVectors(vectors(vectorPoint.getEmbedding()))
+                .putAllPayload(convertToValueMap(vectorPoint.getDocument().toPayload()))
+                .build();
+    }
+
+    // score -> response 변환
+    private RecommendationResponse convertToRecommendation(ScoredPoint scoredPoint) {
+        Map<String, Value> payload = scoredPoint.getPayloadMap();
+        return RecommendationResponse.builder()
+                .productCode(payload.get("productCode").getStringValue())
+                .name(payload.get("name").getStringValue())
+                .description(payload.get("description").getStringValue())
+                .categoryName(payload.get("categoryName").getStringValue())
+                .price((int) payload.get("price").getIntegerValue())
+                .status(payload.get("status").getStringValue())
+                .score(scoredPoint.getScore())
+                .build();
+    }
+
+    // object -> value 변환
+    private Map<String, Value> convertToValueMap(Map<String, Object> payload) {
+        Map<String, Value> valueMap = new java.util.HashMap<>();
+        for (Map.Entry<String, Object> entry : payload.entrySet()) {
+            Object obj = entry.getValue();
+            if (obj instanceof Integer) {
+                valueMap.put(entry.getKey(), value((Integer) obj));
+            } else {
+                valueMap.put(entry.getKey(), value(obj != null ? obj.toString() : ""));
+            }
+        }
+        return valueMap;
+    }
+
+    // float -> list 변환
+    private List<Float> convertToList(float[] array) {
+        List<Float> list = new java.util.ArrayList<>();
+        for (float val : array) {
+            list.add(val);
+        }
+        return list;
+    }
+}

--- a/products/src/main/resources/application-local.yml
+++ b/products/src/main/resources/application-local.yml
@@ -1,8 +1,6 @@
 spring:
   # MySQL 데이터베이스 설정
-  # 로컬에서는 3306으로 사용하셔야 할 것 같습니다. 아마 호남님이 안켜졌던 문제가 각자 로컬에서 3306을 쓰는데 3311로 접속하려고 해서 그런것 아닌가 싶습니다.
   datasource:
-#    url: jdbc:mysql://localhost:3311/product_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     url: jdbc:mysql://localhost:3306/products?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
@@ -38,10 +36,22 @@ spring:
         pool:
           max-active: 5
         shutdown-timeout: 100ms
+
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      embedding:
+        enabled: ${OPENAI_EMBEDDING_ENABLED}
+        options:
+          model: text-embedding-3-small
+          dimensions: 1536
+
 # 로깅 설정
 logging:
   level:
     com.ll.products.domain.search: DEBUG
+    com.ll.products.domain.recommendation: DEBUG
+    org.springframework.ai: DEBUG
     org.springframework.data.elasticsearch: DEBUG
     org.elasticsearch: DEBUG
 
@@ -49,23 +59,21 @@ eureka:
   client:
     enabled: false
 
-#현재 user 포트 8083번이라 일단 수정해놓았는데 이부분 이상있으시면 알려주세요
 api:
   user:
     base-url: http://localhost:8084
-#    base-url: http://localhost:8080
 
 # AWS S3 설정
 cloud:
   aws:
     s3:
       bucket: ${AWS_S3_BUCKET}
-      base-url: https://${AWS_S3_BUCKET}.s3.${AWS_REGION:ap-northeast-2}.amazonaws.com
+      base-url: https://${AWS_S3_BUCKET}.s3.${AWS_REGION}.amazonaws.com
     credentials:
       access-key: ${AWS_ACCESS_KEY}
       secret-key: ${AWS_SECRET_KEY}
     region:
-      static: ${AWS_REGION:ap-northeast-2}
+      static: ${AWS_REGION}
     stack:
       auto: false
 
@@ -73,3 +81,9 @@ management:
   zipkin:
     tracing:
       endpoint: http://localhost:9411/api/v2/spans
+
+# Qdrant 설정
+qdrant:
+  host: localhost
+  port: 6334
+  collection-name: products


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
--- 상품 추천 API 구현
- 핵심 변경 사항 요약
- 상품코드로 유사 상품 조회 API
- 검색 keyword로 유사 상품 조회 API

🔗 관련 이슈
---[product][feat] 상품 추천 API 구현]
- 관련 이슈 번호: #129

📋 요구 사항과 구현 내용
--- 상품 추천 API 구현
- 상품 상세조회 시, 해당 상품과 유사한 상품 조회(score 기반, 기본값 10개)
- 상품 키워드 검색 시, 해당 키워드와 유사한 상품 조회(score 기반, 기본값 10개)
- 유사 상품 조회에서 상세조회한 상품 제외
- 앱 시작 시 컬렉션 재생성 및 인덱싱 되도록 설정(prod 환경에서는 제외)

💬 TODO 리스트
--- 상품db와 벡터db 동기화
- [ ] 상품 CUD API 호출 시(커밋 성공 시) 벡터db에 비동기 이벤트 발행(kafka)
- [ ] es의 springEvent도 추후 kafka로 변경

🧠 고려사항
--- 
- 고민한 점 : 
- embeding 낭비 : 
1. 전체 색인 작업에서 상품 수량만큼 embedding -> 배치 처리하여 임베딩 횟수 감소
2. 임베딩 demension 크기에 따른 비용 고민 -> 비용 그래프 확인 결과, 당장은 1536 사용해도 문제 없을 것. 하지만, 추후 트래픽 증가를 고려하여 512로 줄이는 것 고려해야 함.
- 유사도 정확성 이슈
1. 구매자 입장에서 유사도가 낮은 상품이 더 높은 점수를 받음. ex)"블랙핑크" 검색 시, "블랙팬서" 가 더 높은 유사도로 조회.
2. 벡터db는 단순히 문자의 유사성을 비교하는게 아닌 의미를 비교. 그래도 납득이 가지 않음. -> cosine 유사도 외에 다른 유사도 측정 방식 고려

<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Qdrant 통합 및 설정
 - QdrantConfig 추가: QdrantClient/QdrantGrpcClient 빈 생성(호스트·포트·컬렉션 등), 설정값 주입
 - 시작 시 인덱싱 초기화용 VectorDbIndexerInitializer 추가

2. 벡터 저장소 서비스 및 조작
 - Vector/Store 관련 서비스 추가(업서트·삭제·검색·변환 로직)
 - Qdrant과의 페이로드/포인트 변환 및 컬렉션 관리 구현

3. 임베딩 생성·검증 로직
 - EmbeddingService 추가: 텍스트 생성·검증·임베딩 생성 흐름 제공
 - 임베딩 결과를 벡터 포맷으로 변환해 저장 연계

4. 추천 API 및 컨트롤러
 - RecommendationController 추가: /similar, /search, /reindex, /reindexAllProducts 등 엔드포인트
 - RecommendationService 연동으로 제품 검색·재인덱싱 기능 노출

5. 도메인/페이로드 모델 추가
 - ProductVectorPoint, ProductVectorDoc 등 벡터 문서·포인트 DTO 추가
 - Product → 벡터 페이로드 매핑 및 응답 변환 로직 포함
<!-- AI-GENERATOR:END -->