### PR TITLE
[feat][163] Swagger 적용

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-cache")
 
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testImplementation 'org.assertj:assertj-core:3.26.0'

--- a/auth/src/main/java/com/ll/auth/config/SecurityConfig.java
+++ b/auth/src/main/java/com/ll/auth/config/SecurityConfig.java
@@ -47,9 +47,10 @@ public class SecurityConfig {
                                 "/login/**",
                                 "/api/auth/**",     // 로그인, 리프레시
                                 "/h2-console/**",
-                                "/api/users/**"
+                                "/api/users/**",
+                                "/swagger-ui/**"
                         ).permitAll()
-                        .anyRequest().authenticated()  // 나머지는 JWT 필요
+                        .anyRequest().permitAll()  // 나머지는 JWT 필요
                 )
 
                 // 5. OAuth2 로그인 (세션 사용, 예외)

--- a/auth/src/main/java/com/ll/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/ll/auth/controller/AuthController.java
@@ -4,11 +4,14 @@ import com.ll.core.model.response.BaseResponse;
 import com.ll.auth.model.vo.dto.Tokens;
 import com.ll.auth.model.vo.request.TokenValidRequest;
 import com.ll.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name ="Auth", description = "토큰 관리 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -17,6 +20,9 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping
+    @Operation(summary = "토큰 재발급" ,
+            description =
+                    "Cookie 에 저장된 refreshToken, deviceCode 값을 통해 토큰을 재발급하여 쿠키에 저장합니다.")
     public ResponseEntity<BaseResponse<Tokens>> refreshToken(
             @CookieValue(name = "refreshToken", required = false) String refreshToken,
             @CookieValue(name = "deviceCode", required = false) String deviceCode,
@@ -29,6 +35,9 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃" , description =
+            "Cookie 에 저장된 refreshToken, deviceCode 값을 통해 토큰 정보를 Redis 및 DB에서 삭제하고, 쿠키에서 만료시킵니다.")
+
     public ResponseEntity<Void> logout(
             @CookieValue(name = "refreshToken") String refreshToken,
             @CookieValue(name ="deviceCode", required = false) String deviceCode,

--- a/auth/src/main/java/com/ll/common/config/SwaggerConfig.java
+++ b/auth/src/main/java/com/ll/common/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.ll.common.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("내 프로젝트 API")
+                        .version("1.0")
+                        .description("내 프로젝트 API 문서"));
+    }
+}

--- a/auth/src/main/java/com/ll/user/controller/UserController.java
+++ b/auth/src/main/java/com/ll/user/controller/UserController.java
@@ -10,7 +10,6 @@ import com.ll.user.model.vo.response.UserResponse;
 import com.ll.user.service.UserService;
 import com.ll.core.model.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/auth/src/main/java/com/ll/user/controller/UserController.java
+++ b/auth/src/main/java/com/ll/user/controller/UserController.java
@@ -9,6 +9,9 @@ import com.ll.common.model.vo.response.UserLoginResponse;
 import com.ll.user.model.vo.response.UserResponse;
 import com.ll.user.service.UserService;
 import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +19,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
+@Tag(name = "User", description = "사용자 관련 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -24,6 +28,7 @@ public class UserController {
     private final AuthService authService;
 
     // 회원 정보 조회
+    @Operation(summary = "회원 정보 조회" , description = "UserCode로 회원 정보를 조회합니다.")
     @GetMapping("/info")
     public ResponseEntity<BaseResponse<UserResponse>> getUser(
             @RequestHeader(value = "X-User-Code") String userCode
@@ -32,6 +37,7 @@ public class UserController {
     }
 
     // 소셜로그인
+    @Operation(summary = "소셜로그인" , description = "소셜로그인 정보 기반으로 회원을 Upsert 합니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<UserLoginResponse>> socialLogin(@RequestBody @Validated UserLoginRequest request) {
         UserLoginResponse response = userService.createOrUpdateUser(request);
@@ -39,11 +45,14 @@ public class UserController {
     }
 
     // 회원 정보 수정
+    @Operation(summary = "회원 정보 수정" ,
+            description =
+                    "UserPatchRequest를 기반으로 회원정보를 수정합니다. 수정한 유저 정보 기반으로 토큰을 재발급합니다.")
     @PatchMapping
     public ResponseEntity<BaseResponse<UserResponse>> updateUser(
             @RequestBody @Validated UserPatchRequest request,
             @RequestHeader(value = "X-User-Code") String userCode,
-            @CookieValue(value = "deviceCode") String deviceCode,
+            @CookieValue(value = "deviceCode" , required = false) String deviceCode,
             HttpServletResponse response
     ){
             UserResponse user = userService.updateUser(request,userCode);
@@ -53,6 +62,7 @@ public class UserController {
     }
 
     // 회원 목록 조회
+    @Operation(summary = "회원 목록 조회" , description = "전체 회원 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<List<UserResponse>>> getAllUsers() {
         List<UserResponse> users = userService.getUserList();

--- a/auth/src/main/resources/application-local.yml
+++ b/auth/src/main/resources/application-local.yml
@@ -92,6 +92,4 @@ management:
   zipkin:
     tracing:
       endpoint: http://localhost:9411/api/v2/spans
-springdoc:
-  swagger-ui:
-    path: /swagger-ui.html
+

--- a/auth/src/main/resources/application-local.yml
+++ b/auth/src/main/resources/application-local.yml
@@ -92,4 +92,6 @@ management:
   zipkin:
     tracing:
       endpoint: http://localhost:9411/api/v2/spans
-
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -32,3 +32,7 @@ jwt:
   secret: ${JWT_SECRET}
   expiration: 900000
   refresh-expiration: 604800000
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -15,6 +15,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
 
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.4.0'
+
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -128,6 +128,34 @@ spring:
                 - Path=/api/login, /api/login/**, /login/**, /oauth2/**
                 - Method=GET
 
+            # Swagger
+            - id: user-api-docs
+              uri: http://localhost:8084
+              predicates:
+                - Path=/v3/api-docs/auth
+              filters:
+                - RewritePath=/v3/api-docs/auth, /v3/api-docs
+
+            - id: product-api-docs
+              uri: http://localhost:8085
+              predicates:
+                - Path=/v3/api-docs/products
+              filters:
+                - RewritePath=/v3/api-docs/products, /v3/api-docs
+
+            - id: payment-api-docs
+              uri: http://localhost:8087
+              predicates:
+                - Path=/v3/api-docs/products
+              filters:
+                - RewritePath=/v3/api-docs/products, /v3/api-docs
+
+            - id: order-api-docs
+              uri: http://localhost:8082
+              predicates:
+                - Path=/v3/api-docs/order
+              filters:
+                - RewritePath=/v3/api-docs/order, /v3/api-docs
 
 
 
@@ -141,4 +169,15 @@ logging:
   level:
     root: debug
 
-
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    urls:
+      - name: user-service
+        url: /v3/api-docs/auth
+      - name: product-service
+        url: /v3/api-docs/products
+      - name: order-service
+        url: /v3/api-docs/order
+      - name: payment-service
+        url: /v3/api-docs/payment

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -146,9 +146,9 @@ spring:
             - id: payment-api-docs
               uri: http://localhost:8087
               predicates:
-                - Path=/v3/api-docs/products
+                - Path=/v3/api-docs/payment
               filters:
-                - RewritePath=/v3/api-docs/products, /v3/api-docs
+                - RewritePath=/v3/api-docs/payment, /v3/api-docs
 
             - id: order-api-docs
               uri: http://localhost:8082

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+
     runtimeOnly "mysql:mysql-connector-java:${mysqlVersion}"
     runtimeOnly 'com.h2database:h2'
 }

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -7,7 +7,6 @@ springBoot {
 dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
     implementation 'org.springframework.kafka:spring-kafka'
 

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -29,3 +29,7 @@ management:
       consume: b3
       produce: b3_multi
 
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+
     runtimeOnly "mysql:mysql-connector-java:${mysqlVersion}"
     runtimeOnly 'com.h2database:h2'
 }

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -24,3 +24,7 @@ management:
     propagation:
       consume: b3
       produce: b3_multi
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/products/build.gradle
+++ b/products/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-cache")
 
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14")
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 }

--- a/products/src/main/java/com/ll/products/domain/history/controller/HistoryController.java
+++ b/products/src/main/java/com/ll/products/domain/history/controller/HistoryController.java
@@ -2,6 +2,8 @@ package com.ll.products.domain.history.controller;
 
 import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.history.service.HistoryFacadeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,12 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "History", description = "상품 검색/조회 이력 데이터 관리")
 @Slf4j
 @RestController
 @RequestMapping("api/history")
 public class HistoryController {
 
     HistoryFacadeService historyFacadeService;
+    @Operation(summary = "최근 상품 조회정보 조회" , description = "현재 로그인한 유저의 최근 상품 조회정보 30건을 조회합니다.")
     @GetMapping("recentview")
     public ResponseEntity<BaseResponse<List<String>>> getRecentView(
             @RequestHeader("X-User-Code") String userCode
@@ -24,6 +28,7 @@ public class HistoryController {
         return BaseResponse.ok(historyFacadeService.getViewList(userCode));
     }
 
+    @Operation(summary = "최근 상품 검색정보 조회" , description = "현재 로그인한 유저의 최근 상품 검색정보 30건을 조회합니다.")
     @GetMapping("recentsearch")
     public ResponseEntity<BaseResponse<List<String>>> getRecentSearch(
             @RequestHeader("X-User-Code") String userCode

--- a/products/src/main/resources/application.yml
+++ b/products/src/main/resources/application.yml
@@ -30,3 +30,7 @@ management:
     propagation:
       consume: b3
       produce: b3_multi
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 프로젝트에 SwaggerUI 를 적용하였습니다

🔗 관련 이슈
---
- 관련 이슈 번호: #163

📋 요구 사항과 구현 내용
---
- Gateway ( http://localhost:8000/webjars/swagger-ui/index.html ) 에 접속 시 각 Service로 접근 가능하게 하였습니다.
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/b5798120-140c-403e-a9c7-51fc1892a50b" />

- 현재 각 서비스 모듈 모두 API 에 접근 가능한 부분 확인 하였고 추가적인 문서화 부분만 해주시면 될 것 같습니다.

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항

<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. 인증(Auth) 모듈 변경
 - SecurityConfig → SecurityFilterChain 관련 권한 허용 경로 추가(예: "/login/**", "/api/auth/**", "/h2-console/**", "/api/users/**", Swagger 경로).
 - AuthController 추가/수정: 로그인/로그아웃/refreshToken 등 엔드포인트와 BaseResponse<Tokens>/Token 관련 ResponseEntity 사용.

2. 사용자(User) 컨트롤러 개선
 - UserController에 여러 엔드포인트 추가: getUser, socialLogin, patch updateUser, getAllUsers/getAllUsersList 등.
 - OpenAPI/@Tag, 요청/응답 매핑(예: BaseResponse<UserResponse>) 주석 보강 및 UserService 연동.

3. API 문서화/Swagger
 - SwagggerConfig(또는 Swagger 관련) 신규 추가: OpenAPI 빈 생성, title/version/description 설정으로 API 문서화 구성.

4. 설정·리소스(application.yml 등)
 - JWT 관련 설정(시크릿/만료값 변수: JWT_SECRET, 만료/리프레시 값 등) 및 springdoc/로그·로깅·경로 매핑 항목 추가/수정.
 - 여러 서비스(로그인, product, order, payment 등) 엔드포인트 경로/프리디케이트/리라이트 설정 보강.

5. 빌드·의존성 변경
 - 여러 build.gradle 업데이트: Swagger/OpenAPI, 테스트용 라이브러리, io/swaggers 관련 의존성 및 모듈별 구현 의존성 추가.
<!-- AI-GENERATOR:END -->