### PR TITLE
[docs][194] Auth 모듈 Swagger Docs 작성

### DIFF
--- a/auth/src/main/java/com/ll/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/ll/auth/controller/AuthController.java
@@ -1,20 +1,20 @@
 package com.ll.auth.controller;
+
+import com.ll.auth.controller.swagger.LogoutApiResponse;
+import com.ll.auth.controller.swagger.RefreshTokenApiResponse;
 import com.ll.auth.util.CookieUtil;
 import com.ll.core.model.response.BaseResponse;
 import com.ll.auth.model.vo.dto.Tokens;
 import com.ll.auth.model.vo.request.TokenValidRequest;
 import com.ll.auth.service.AuthService;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name ="Auth", description = "토큰 관리 API")
+@Tag(name = "Auth", description = "토큰 관리 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -23,40 +23,32 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping
-    @Operation(summary = "01. 토큰 재발급" ,
-            description =
-                    "Cookie 에 저장된 refreshToken, deviceCode 값을 통해 토큰을 재발급하여 쿠키에 저장합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode ="200" , description = "토큰 재발급 성공"),
-            @ApiResponse(responseCode ="401" , description = "refreshToken 이나 deviceCode가 제공되지않음"),
-            @ApiResponse(responseCode ="404" , description = "해당정보로 토큰을 찾을 수 없음")
-    })
+    @RefreshTokenApiResponse
     public ResponseEntity<BaseResponse<Tokens>> refreshToken(
             @Parameter(hidden = true)
             @CookieValue(name = "refreshToken", required = false) String refreshToken,
             @Parameter(hidden = true)
             @CookieValue(name = "deviceCode", required = false) String deviceCode,
             HttpServletResponse response
-    ){
-        TokenValidRequest validRequest = new TokenValidRequest(refreshToken,deviceCode);
+    ) {
+        TokenValidRequest validRequest = new TokenValidRequest(refreshToken, deviceCode);
         Tokens tokens = authService.refreshToken(validRequest);
-        CookieUtil.setTokenCookie(response, tokens.accessToken(),  tokens.refreshToken());
+        CookieUtil.setTokenCookie(response, tokens.accessToken(), tokens.refreshToken());
         return BaseResponse.ok(tokens);
     }
 
     @PostMapping("/logout")
-    @Operation(summary = "02. 로그아웃" , description =
-            "Cookie 에 저장된 refreshToken, deviceCode 값을 통해 토큰 정보를 Redis 및 DB에서 삭제하고, 쿠키에서 만료시킵니다.")
-
-    public ResponseEntity<Void> logout(
+    @LogoutApiResponse
+    public ResponseEntity<BaseResponse<Void>> logout(
             @Parameter(hidden = true)
-            @CookieValue(name = "refreshToken") String refreshToken,
+            @CookieValue(name = "refreshToken", required = false) String refreshToken,
             @Parameter(hidden = true)
-            @CookieValue(name ="deviceCode", required = false) String deviceCode,
+            @CookieValue(name = "deviceCode", required = false) String deviceCode,
             HttpServletResponse response
-    ){
-        authService.logoutUser(refreshToken,deviceCode);
+    ) {
+        TokenValidRequest validRequest = new TokenValidRequest(refreshToken, deviceCode);
+        authService.logoutUser(validRequest);
         CookieUtil.expiredAuthCookie(response);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok(null);
     }
 }

--- a/auth/src/main/java/com/ll/auth/controller/swagger/LogoutApiResponse.java
+++ b/auth/src/main/java/com/ll/auth/controller/swagger/LogoutApiResponse.java
@@ -1,0 +1,96 @@
+package com.ll.auth.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "02. 로그아웃",
+        description = """
+                쿠키(refreshToken, deviceCode)에 저장된 정보를 기반으로
+                사용자 인증 정보를 삭제합니다.
+                
+                - Redis 및 DB에서 해당 refreshToken 정보를 제거하고
+                - 브라우저 쿠키의 refreshToken, accessToken, deviceCode 를 만료시킵니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "refreshToken",
+                in = ParameterIn.COOKIE,
+                description = "사용자의 Refresh Token 값"
+        ),
+        @Parameter(
+                name = "deviceCode",
+                in = ParameterIn.COOKIE,
+                description = "기기를 식별하기 위한 고유 deviceCode 값"
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "로그아웃 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 로그아웃 성공",
+                                        description = "토큰 삭제 및 쿠키 만료가 정상적으로 처리된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": null
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "필수 쿠키(refreshToken 또는 deviceCode)가 누락되었습니다.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - refreshToken 누락",
+                                        description = "refreshToken 쿠키가 전달되지 않은 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "요청에 refreshToken 이 제공되지 않았습니다.",
+                                                  "errorCode": "TOKEN_NOT_PROVIDED"
+                                                }
+                                                """
+                                ),
+                                @ExampleObject(
+                                        name = "400 - deviceCode 누락",
+                                        description = "deviceCode 쿠키가 전달되지 않은 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "요청에 deviceCode 가 제공되지 않았습니다.",
+                                                  "errorCode": "DEVICE_CODE_NOT_PROVIDED"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface LogoutApiResponse {
+}

--- a/auth/src/main/java/com/ll/auth/controller/swagger/RefreshTokenApiResponse.java
+++ b/auth/src/main/java/com/ll/auth/controller/swagger/RefreshTokenApiResponse.java
@@ -1,0 +1,118 @@
+package com.ll.auth.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "01. 토큰 재발급",
+        description = """
+                저장된 refreshToken 및 deviceCode(쿠키)를 기반으로
+                새로운 Access Token 및 Refresh Token을 재발급합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "refreshToken",
+                in = ParameterIn.COOKIE,
+                description = "사용자의 Refresh Token 값"
+        ),
+        @Parameter(
+                name = "deviceCode",
+                in = ParameterIn.COOKIE,
+                description = "기기를 식별하기 위한 고유 deviceCode 값"
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "토큰 재발급 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 토큰 재발급 성공",
+                                        description = "refreshToken 검증 후 새로운 accessToken 및 refreshToken 이 발급됩니다.",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": {
+                                                    "accessToken": "eyJhbGciOiJIUzI1NiJ9....",
+                                                    "refreshToken": "eyJhbGciOiJIUzI1NiJ9...."
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "필수 쿠키(refreshToken 또는 deviceCode)가 누락되었습니다.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - refreshToken 누락",
+                                        description = "refreshToken 쿠키가 전달되지 않은 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "요청에 refreshToken 이 제공되지 않았습니다.",
+                                                  "errorCode": "TOKEN_NOT_PROVIDED"
+                                                }
+                                                """
+                                ),
+                                @ExampleObject(
+                                        name = "400 - deviceCode 누락",
+                                        description = "deviceCode 쿠키가 전달되지 않은 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "요청에 deviceCode 가 제공되지 않았습니다.",
+                                                  "errorCode": "DEVICE_CODE_NOT_PROVIDED"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "해당 refreshToken 또는 deviceCode 에 대한 유효한 토큰을 찾을 수 없습니다.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 토큰 검색 실패",
+                                        description = "전달된 refreshToken / deviceCode 로 저장된 토큰을 찾을 수 없는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "리프레시 토큰을 찾을 수 없습니다。",
+                                                  "errorCode": "TOKEN_NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface RefreshTokenApiResponse {
+}

--- a/auth/src/main/java/com/ll/auth/service/AuthService.java
+++ b/auth/src/main/java/com/ll/auth/service/AuthService.java
@@ -35,7 +35,7 @@ public class AuthService {
     }
 
     public Tokens refreshToken(TokenValidRequest request) {
-        ValidationTokenRequest(request);
+        ValidateTokenRequest(request);
 
         try {
             if (!redisService.validRefreshToken(request.refreshToken(), request.deviceCode())) {
@@ -86,7 +86,7 @@ public class AuthService {
     }
 
     public void logoutUser(TokenValidRequest request){
-        ValidationTokenRequest(request);
+        ValidateTokenRequest(request);
         try{
             redisService.deleteRefreshToken(request.refreshToken(),request.deviceCode());
         }
@@ -105,7 +105,7 @@ public class AuthService {
         }
     }
 
-    private void ValidationTokenRequest(TokenValidRequest request){
+    private void ValidateTokenRequest(TokenValidRequest request){
         if (request.refreshToken() == null || request.refreshToken().isEmpty()) {
             throw new TokenNotProvidedException();
         }

--- a/auth/src/main/java/com/ll/auth/service/AuthService.java
+++ b/auth/src/main/java/com/ll/auth/service/AuthService.java
@@ -35,13 +35,7 @@ public class AuthService {
     }
 
     public Tokens refreshToken(TokenValidRequest request) {
-
-        if (request.refreshToken() == null || request.refreshToken().isEmpty()) {
-            throw new TokenNotProvidedException();
-        }
-        if (request.deviceCode() == null || request.deviceCode().isEmpty()) {
-            throw new DeviceCodeNotProvidedException();
-        }
+        ValidationTokenRequest(request);
 
         try {
             if (!redisService.validRefreshToken(request.refreshToken(), request.deviceCode())) {
@@ -91,15 +85,16 @@ public class AuthService {
         return tokens;
     }
 
-    public void logoutUser(String refreshToken , String deviceCode){
+    public void logoutUser(TokenValidRequest request){
+        ValidationTokenRequest(request);
         try{
-            redisService.deleteRefreshToken(refreshToken,deviceCode);
+            redisService.deleteRefreshToken(request.refreshToken(),request.deviceCode());
         }
         catch(Exception e){
             log.error(e.getMessage());
         }
         finally {
-            authAsyncService.asyncDelete(refreshToken);
+            authAsyncService.asyncDelete(request.refreshToken());
         }
 
     }
@@ -110,5 +105,14 @@ public class AuthService {
         }
     }
 
+    private void ValidationTokenRequest(TokenValidRequest request){
+        if (request.refreshToken() == null || request.refreshToken().isEmpty()) {
+            throw new TokenNotProvidedException();
+        }
+        if (request.deviceCode() == null || request.deviceCode().isEmpty()) {
+            throw new DeviceCodeNotProvidedException();
+        }
+
+    }
 
 }

--- a/auth/src/main/java/com/ll/user/controller/UserController.java
+++ b/auth/src/main/java/com/ll/user/controller/UserController.java
@@ -3,12 +3,14 @@ package com.ll.user.controller;
 import com.ll.auth.model.vo.dto.Tokens;
 import com.ll.auth.service.AuthService;
 import com.ll.auth.util.CookieUtil;
+import com.ll.user.controller.swagger.UserGetApiResponse;
+import com.ll.user.controller.swagger.UserListApiResponse;
+import com.ll.user.controller.swagger.UserUpdateApiResponse;
 import com.ll.user.model.vo.request.UserPatchRequest;
 
 import com.ll.user.model.vo.response.UserResponse;
 import com.ll.user.service.UserService;
 import com.ll.core.model.response.BaseResponse;
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
@@ -27,7 +29,7 @@ public class UserController {
     private final AuthService authService;
 
     // 회원 목록 조회
-    @Operation(summary = "01. 회원 목록 조회" , description = "전체 회원 목록을 조회합니다.")
+    @UserListApiResponse
     @GetMapping
     public ResponseEntity<BaseResponse<List<UserResponse>>> getAllUsers() {
         List<UserResponse> users = userService.getUserList();
@@ -35,7 +37,7 @@ public class UserController {
     }
 
     // 회원 정보 조회
-    @Operation(summary = "02. 회원 정보 조회" , description = "UserCode로 회원 정보를 조회합니다.")
+    @UserGetApiResponse
     @GetMapping("/info")
     public ResponseEntity<BaseResponse<UserResponse>> getUser(
             @Parameter(hidden = true)
@@ -45,13 +47,7 @@ public class UserController {
     }
 
     // 회원 정보 수정
-    @Operation(summary = "03. 회원 정보 수정" ,
-            description =
-                    """
-                            UserPatchRequest를 기반으로 회원정보를 수정합니다.
-                            수정한 유저 정보 기반으로 토큰을 재발급합니다.
-                            Cookie의 AccessToken을 Gateway가 검증하여 userCode를 추출합니다.
-                            Cookie의 deviceCode와 userCode를 사용해 토큰을 저장합니다.""")
+    @UserUpdateApiResponse
     @PatchMapping
     public ResponseEntity<BaseResponse<UserResponse>> updateUser(
             @RequestBody @Validated UserPatchRequest request,

--- a/auth/src/main/java/com/ll/user/controller/swagger/UserGetApiResponse.java
+++ b/auth/src/main/java/com/ll/user/controller/swagger/UserGetApiResponse.java
@@ -1,0 +1,132 @@
+package com.ll.user.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "02. 회원 정보 조회",
+        description = """
+                현재 로그인된 사용자의 정보를 조회합니다.
+                
+                - Gateway 에서 AccessToken을 검증 후, UserCode 값을 X-User-Code 헤더에 주입하여 전달합니다.
+                - 외부 모듈에서 직접 UserCode 값을 X-User-Code 헤더에 주입하여 전달합니다.
+                - 전달받은 X-User-Code 기반으로 회원 정보를 조회합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "로그인된 사용자의 UserCode",
+                required = true
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "회원 정보 조회 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "200 - Success",
+                                description = "회원 정보 조회 성공 예시",
+                                value = """
+                                        {
+                                          "status": 200,
+                                          "message": "success",
+                                          "data": {
+                                            "id": 4,
+                                            "code": "019b1066-61c7-7191-b26c-13b0fd49e563",
+                                            "socialId": "106941175659269314812",
+                                            "socialProvider": "GOOGLE",
+                                            "email": "als981209@gmail.com",
+                                            "name": "김민석",
+                                            "role": "USER",
+                                            "profileImageUrl": null,
+                                            "mannerScore": 5,
+                                            "grade": "BRONZE",
+                                            "accountStatus": "ACTIVE",
+                                            "accountBank": null,
+                                            "accountNumber": null,
+                                            "createAt": "2025-12-12T11:31:43.815633",
+                                            "updatedAt": "2025-12-12T11:31:43.815633"
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "필수 헤더 누락",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "400 - Missing Header",
+                                description = "X-User-Code 헤더가 누락된 경우",
+                                value = """
+                                        {
+                                          "status": 400,
+                                          "message": "필수 헤더 'X-User-Code'가 누락되었습니다.",
+                                          "errorCode": "BAD_REQUEST"
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401",
+                description = "인증 실패",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "401 - Unauthorized",
+                                description = "AccessToken 검증 실패 등 인증이 유효하지 않은 경우",
+                                value = """
+                                        {
+                                          "status": 401,
+                                          "message": "인증 정보가 유효하지 않습니다.",
+                                          "errorCode": "UNAUTHORIZED"
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "회원 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "404 - User Not Found",
+                                description = "해당 UserCode로 회원을 찾을 수 없는 경우",
+                                value = """
+                                        {
+                                          "status": 404,
+                                          "message": "유저를 찾을 수 없습니다.",
+                                          "errorCode": "NOT_FOUND"
+                                        }
+                                        """
+                        )
+                )
+        )
+})
+public @interface UserGetApiResponse {
+}

--- a/auth/src/main/java/com/ll/user/controller/swagger/UserListApiResponse.java
+++ b/auth/src/main/java/com/ll/user/controller/swagger/UserListApiResponse.java
@@ -1,0 +1,61 @@
+package com.ll.user.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "01. 회원 목록 조회",
+        description = """
+                등록된 모든 회원의 정보를 조회합니다.
+                """
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "회원 목록 조회 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 회원 목록 조회 성공",
+                                        description = "회원 목록이 정상적으로 조회된 경우의 응답 예시",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": [
+                                                    {
+                                                      "userCode": "019b1001-ee08-7c8b-8b32-b29936f5ebfc",
+                                                      "name": "홍길동",
+                                                      "email": "hong@example.com",
+                                                      "phone": "010-1234-5678",
+                                                      "role": "USER"
+                                                    },
+                                                    {
+                                                      "userCode": "039c2002-ax09-7c9f-1c11-c03311g8xz21",
+                                                      "name": "김철수",
+                                                      "email": "chulsoo@example.com",
+                                                      "phone": "010-9876-5432",
+                                                      "role": "ADMIN"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface UserListApiResponse {
+}

--- a/auth/src/main/java/com/ll/user/controller/swagger/UserUpdateApiResponse.java
+++ b/auth/src/main/java/com/ll/user/controller/swagger/UserUpdateApiResponse.java
@@ -1,0 +1,163 @@
+package com.ll.user.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.user.model.vo.request.UserPatchRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "03. 회원 정보 수정",
+        description = """
+                - UserPatchRequest 기반으로 회원 정보를 수정합니다.
+                - 수정된 회원 정보로 AccessToken / RefreshToken 을 재발급합니다.
+                - Cookie 의 AccessToken 은 Gateway 가 검증하며 그 과정에서 X-User-Code 가 주입됩니다.
+                - Cookie 의 deviceCode 와 userCode 를 조합하여 새로운 토큰을 저장합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "Gateway 에서 AccessToken 검증 후 주입되는 UserCode"
+        ),
+        @Parameter(
+                name = "deviceCode",
+                in = ParameterIn.COOKIE,
+                description = "기기 식별용 deviceCode (refreshToken 재발급 시 사용)"
+        )
+})
+@RequestBody(
+        description = "유저 정보 변경 요청 Body",
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = UserPatchRequest.class),
+                examples = @ExampleObject(
+                        name = "유저 정보 변경 요청 예시",
+                        value = """
+                                {
+                                  "mannerScore" : 99,
+                                  "role" : "SELLER"
+                                }
+                                """
+                )
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "회원 정보 수정 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "200 - 회원 정보 수정 성공",
+                                description = "정상적으로 회원 정보가 수정된 경우",
+                                value = """
+                                        {
+                                          "status": 200,
+                                          "message": "success",
+                                          "data": {
+                                            "id": 4,
+                                            "code": "019b1066-61c7-7191-b26c-13b0fd49e563",
+                                            "email": "new_email@example.com",
+                                            "name": "김민석",
+                                            "role": "USER",
+                                            "profileImageUrl": "https://image/new.png",
+                                            "mannerScore": 5,
+                                            "grade": "BRONZE",
+                                            "accountStatus": "ACTIVE",
+                                            "createAt": "2025-12-12T11:31:43.815633",
+                                            "updatedAt": "2025-12-12T11:59:01.123456"
+                                          }
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "요청값 검증 실패",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - Validation 실패",
+                                        description = "UserPatchRequest 값이 유효하지 않을 때",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "올바른 형식의 이메일 주소여야 합니다",
+                                                  "errorCode": "BAD_REQUEST"
+                                                }
+                                                """
+                                ),
+                                @ExampleObject(
+                                        name = "400 - X-User-Code 헤더 누락",
+                                        description = "X-User-Code 헤더가 누락된 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "필수 헤더 'X-User-Code'가 누락되었습니다.",
+                                                  "errorCode": "BAD_REQUEST"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "401",
+                description = "인증 실패 (AccessToken 또는 UserCode 문제)",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "401 - 인증 실패",
+                                description = "AccessToken이 만료되었거나 UserCode 가 유효하지 않을 때",
+                                value = """
+                                        {
+                                          "status": 401,
+                                          "message": "인증 정보가 유효하지 않습니다.",
+                                          "errorCode": "UNAUTHORIZED"
+                                        }
+                                        """
+                        )
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "대상 회원을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = @ExampleObject(
+                                name = "404 - 회원 없음",
+                                description = "수정하려는 회원이 존재하지 않을 때",
+                                value = """
+                                        {
+                                          "status": 404,
+                                          "message": "유저를 찾을 수 없습니다.",
+                                          "errorCode": "NOT_FOUND"
+                                        }
+                                        """
+                        )
+                )
+        )
+})
+public @interface UserUpdateApiResponse {
+}

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -125,7 +125,7 @@ spring:
             - id: auth-route-public
               uri: http://localhost:8084
               predicates:
-                - Path=/api/auth
+                - Path=/api/auth, /api/auth/**
                 - Method=POST
             # Login
             - id: auth-route-login


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Auth 모듈 Swagger Docs 작성

🔗 관련 이슈
---
- 관련 이슈 번호: #194

📋 요구 사항과 구현 내용
---
- Auth 모듈 Swagger Docs 작성

💬 TODO 리스트
---

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등






<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Auth 토큰/로그아웃 API 구조 및 검증 로직 개선 
 - `AuthController`에서 Swagger 기본 어노테이션 제거 후 `@RefreshTokenApiResponse`, `@LogoutApiResponse` 커스텀 메타 어노테이션으로 대체 
 - refreshToken 재발급 시 `TokenValidRequest` 생성 후 `AuthService.refreshToken` 호출, 쿠키 설정 로직 공백/포맷 정리 
 - 로그아웃 API 응답을 `ResponseEntity<BaseResponse<Void>>`로 변경하고, `BaseResponse.ok(null)` 반환으로 일원화 
 - 로그아웃 요청 파라미터를 nullable 쿠키(`required = false`)로 변경하고 `TokenValidRequest`로 묶어 서비스에 전달 

2. AuthService 토큰 검증 로직 공통화 및 로그아웃 시그니처 변경 
 - `refreshToken`에서 수행하던 refreshToken/deviceCode null·empty 체크를 `ValidateTokenRequest(TokenValidRequest)` private 메서드로 추출 
 - `logoutUser` 시그니처를 `(String refreshToken, String deviceCode)`에서 `TokenValidRequest`로 변경하고, 내부에서 공통 검증 메서드 호출 
 - Redis 삭제와 `authAsyncService.asyncDelete` 호출 시 `TokenValidRequest`에서 값을 꺼내 사용하도록 수정 

3. Auth/User API용 Swagger 메타 어노테이션 도입 
 - `RefreshTokenApiResponse`, `LogoutApiResponse` 생성: 쿠키 파라미터, 응답 코드(200/400/404 등) 및 예시 응답 JSON 정의 
 - `UserListApiResponse`, `UserGetApiResponse`, `UserUpdateApiResponse` 추가: 각 User API 엔드포인트의 summary/description, 헤더·쿠키·Body 스펙, 성공/에러 응답 예시를 세부적으로 명세 
 - `UserController`에서 기존 `@Operation` 제거 후 위 메타 어노테이션으로 교체하여 Swagger 문서 정의를 분리 

4. Gateway 라우팅 설정 수정 
 - `application-local.yml`에서 `auth-route-public`의 Path 조건을 `/api/auth` 단일 경로에서 `/api/auth, /api/auth/**`로 확장하여 하위 경로 POST 요청도 auth 서비스로 라우팅되도록 변경
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [로그아웃 API 응답 스펙/실제 동작 불일치 (필수 쿠키 required=false 변경)]
 - [x] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - AuthController.logout 에서 `@CookieValue(name = "refreshToken")`가 `required = false` 로 변경되었고, `deviceCode` 도 optional로 되어 있음에도, `AuthService.logoutUser` 내부 `ValidateTokenRequest`가 두 값이 비어있으면 예외(TokenNotProvidedException, DeviceCodeNotProvidedException)를 바로 던지도록 되어 있음.
 - 한편 `LogoutApiResponse`에서는 400 응답과 예시를 명시하고 있으나, 실제 코드는 해당 예외를 400으로 매핑하는 로직이 diff 내에 보이지 않음(판단 불가 부분 있음).
 - 결과:
 - refreshToken/deviceCode 쿠키가 없는 상태에서 `/api/auth/logout` 을 호출하면, 컨트롤러에서 200 응답이 아닌 예외가 발생하여 전역 예외 처리 방식에 따라 500 등 의도치 않은 응답이 나갈 수 있음.
 - Swagger 문서상 “필수 쿠키 누락 시 400”이라고 되어 있지만, 실제 런타임 응답 코드가 다를 가능성이 높아 클라이언트 구현과 장애 대응에 혼선을 줄 수 있음.
 - 위험성:
 - 인증/로그아웃 흐름에서 필수 쿠키가 누락된 일반적인 케이스에서 서버 에러로 처리될 수 있어, 예측 불가능한 장애와 로그오염을 유발할 수 있음.
 - 보안/인증 관련 엔드포인트의 예외 응답 코드 불일치는 운영 중 디버깅과 클라이언트 측 오류 처리 로직에 직접적인 악영향을 줄 수 있음.

2. [RefreshTokenApiResponse 예시 메시지 내 문장부호 비표준 사용]
 - [x] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - `RefreshTokenApiResponse`의 404 예시 메시지 `"리프레시 토큰을 찾을 수 없습니다。"` 에서 마침표가 전각 문자(중국어/일본어용 `。`)로 기입되어 있음.
 - 이는 코드 상 그대로 API 문서/스니펫에 노출됨.
 - 결과:
 - 다국어/문자 인코딩 처리 환경에 따라 문구 검색, 로그 필터링, 클라이언트 쪽 문자열 매칭 시 동일 문장처럼 인식되지 않을 수 있음.
 - 위험성:
 - 기능 동작 자체를 깨지는 않지만, 에러 코드/메시지 기반 로직(예: 클라이언트에서 메시지 substring 매칭, 모니터링 룰 작성)에 쓰일 경우 오작동을 유발할 수 있는 잠재적 데이터 무결성/운영 위험 요소임.

3. [Gateway 라우팅 범위 확장에 따른 비(非)의도 엔드포인트 노출 가능성]
 - [x] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - `gateway/src/main/resources/application-local.yml` 에서 `auth-route-public` 의 Path predicate 가 `/api/auth` → `/api/auth, /api/auth/**` 로 확장됨.
 - diff 상 이 라우트가 어떤 필터(인증/인가, CORS, RateLimit 등)를 거치는지 추가 문맥이 보이지 않아, auth 서브 경로 전체가 "public" 으로 취급되는지 여부를 판단할 수 없음.
 - 결과:
 - 만약 이 라우트가 실제로 인증 없이 접근 가능한 public 라우트라면, `/api/auth/**` 하위의 보안 민감 엔드포인트까지 인증 없이 외부에 노출될 수 있음.
 - 위험성:
 - 판단 불가: 라우트에 적용된 필터/시큐리티 설정이 diff에 없으므로 실제 보안 영향은 확정할 수 없음.
 - 잠정적 문제 가능성: 잘못된 라우팅 설정이면 토큰 재발급/로그아웃 등의 민감 API 가 비인가 접근에 노출되는 심각한 보안 리스크가 될 수 있어, 설정 의도와 시큐리티 체인을 반드시 재확인해야 함.
<!-- AI-REVIEW:END -->