### PR TITLE
[feat][196] 상품 DLQ 이벤트 저장 및 kakfa topic 통합

### DIFF
--- a/infra/scripts/00-env.sh
+++ b/infra/scripts/00-env.sh
@@ -32,12 +32,6 @@ declare -A DEFAULT_TOPICS=(
   ["inventory-event.dlq"]=1
   ["product-event"]=1
   ["product-event.dlq"]=1
-#  ["product-updated-event"]=1
-#  ["product-deleted-event"]=1
-#  ["product-updated-status-event"]=1
-#  ["product-updated-event.dlq"]=1
-#  ["product-deleted-event.dlq"]=1
-#  ["product-updated-status-event.dlq"]=1
 )
 
 # 시간 포맷

--- a/infra/scripts/00-env.sh
+++ b/infra/scripts/00-env.sh
@@ -30,12 +30,14 @@ declare -A DEFAULT_TOPICS=(
   ["refund-event.dlq"]=1
   ["inventory-event"]=1
   ["inventory-event.dlq"]=1
-  ["product-updated-event"]=1
-  ["product-deleted-event"]=1
-  ["product-updated-status-event"]=1
-  ["product-updated-event.dlq"]=1
-  ["product-deleted-event.dlq"]=1
-  ["product-updated-status-event.dlq"]=1
+  ["product-event"]=1
+  ["product-event.dlq"]=1
+#  ["product-updated-event"]=1
+#  ["product-deleted-event"]=1
+#  ["product-updated-status-event"]=1
+#  ["product-updated-event.dlq"]=1
+#  ["product-deleted-event.dlq"]=1
+#  ["product-updated-status-event.dlq"]=1
 )
 
 # 시간 포맷

--- a/products/src/main/java/com/ll/products/domain/product/event/ProductEventListener.java
+++ b/products/src/main/java/com/ll/products/domain/product/event/ProductEventListener.java
@@ -1,5 +1,6 @@
 package com.ll.products.domain.product.event;
 
+import com.ll.products.domain.product.messaging.producer.ProductEventProducer;
 import com.ll.products.domain.product.model.entity.Product;
 import com.ll.products.domain.search.document.ProductDocument;
 import com.ll.products.domain.search.repository.ProductSearchRepository;

--- a/products/src/main/java/com/ll/products/domain/product/messaging/consumer/ProductEventDlqConsumer.java
+++ b/products/src/main/java/com/ll/products/domain/product/messaging/consumer/ProductEventDlqConsumer.java
@@ -1,0 +1,56 @@
+package com.ll.products.domain.product.messaging.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.products.domain.product.model.entity.DlqStatus;
+import com.ll.products.domain.product.model.entity.ProductDlqEvent;
+import com.ll.products.domain.product.repository.ProductDlqEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductEventDlqConsumer {
+
+    private final ProductDlqEventRepository productDlqEventRepository;
+    private final ObjectMapper objectMapper;
+
+
+    private static final String PRODUCT_DLQ_TOPIC = "product-event.dlq";
+    private static final String DLQ_GROUP_ID = "product-dlq-group";
+
+    @KafkaListener(
+            topics = PRODUCT_DLQ_TOPIC,
+            groupId = DLQ_GROUP_ID
+    )
+    public void consumeDlqEvent(ConsumerRecord<String, Object> record) {
+        log.error("DLQ 이벤트 수신: topic={}, partition={}, offset={}, key={}",
+                record.topic(), record.partition(), record.offset(), record.key());
+        try {
+            ProductDlqEvent dlqEvent = buildDlqEvent(record);
+            productDlqEventRepository.save(dlqEvent);
+            log.info("DLQ 이벤트 저장 완료: id={}, topic={}",
+                    dlqEvent.getId(), record.topic());
+        } catch (Exception e) {
+            log.error("DLQ 이벤트 저장 실패: topic={}, error={}", record.topic(), e.getMessage(), e);
+        }
+    }
+
+    // record -> productDlqEvent
+    private ProductDlqEvent buildDlqEvent(ConsumerRecord<String, Object> record) throws JsonProcessingException {
+        String eventPayload = objectMapper.writeValueAsString(record.value());
+        ProductDlqEvent dlqEvent = ProductDlqEvent.builder()
+                .topic(record.topic())
+                .eventPayload(eventPayload)
+                .failedAt(LocalDateTime.now())
+                .status(DlqStatus.PENDING)
+                .build();
+        return dlqEvent;
+    }
+}

--- a/products/src/main/java/com/ll/products/domain/product/messaging/producer/ProductEventProducer.java
+++ b/products/src/main/java/com/ll/products/domain/product/messaging/producer/ProductEventProducer.java
@@ -1,4 +1,4 @@
-package com.ll.products.domain.product.event;
+package com.ll.products.domain.product.messaging.producer;
 
 import com.ll.core.config.kafka.KafkaEventPublisher;
 import com.ll.core.model.vo.kafka.ProductEvent;
@@ -16,10 +16,7 @@ import java.time.format.DateTimeFormatter;
 @RequiredArgsConstructor
 public class ProductEventProducer {
 
-    private static final String PRODUCT_UPDATE_TOPIC = "product-updated-event";
-    private static final String PRODUCT_DELETE_TOPIC = "product-deleted-event";
-    private static final String PRODUCT_UPDATE_STATUS_TOPIC = "product-updated-status-event";
-
+    private static final String PRODUCT_TOPIC = "product-event";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
     private final KafkaEventPublisher kafkaEventPublisher;
@@ -27,21 +24,21 @@ public class ProductEventProducer {
     // 1. 상품 수정 이벤트 발행
     public void publishProductUpdated(Product product) {
         ProductEvent event = buildProductEvent(product, ProductEventType.PRODUCT_UPDATED);
-        kafkaEventPublisher.publish(PRODUCT_UPDATE_TOPIC, event);
+        kafkaEventPublisher.publish(PRODUCT_TOPIC, event);
         log.info("상품 수정 이벤트 발행: productCode={}", product.getCode());
     }
 
     // 2. 상품 삭제 이벤트 발행
     public void publishProductDeleted(Product product) {
         ProductEvent event = buildProductEvent(product, ProductEventType.PRODUCT_DELETED);
-        kafkaEventPublisher.publish(PRODUCT_DELETE_TOPIC, event);
+        kafkaEventPublisher.publish(PRODUCT_TOPIC, event);
         log.info("상품 삭제 이벤트 발행: productCode={}", product.getCode());
     }
 
     // 3. 상품 상태 변경 이벤트 발행
     public void publishProductUpdatedStatus(Product product) {
         ProductEvent event = buildProductEvent(product, ProductEventType.PRODUCT_UPDATED_STATUS);
-        kafkaEventPublisher.publish(PRODUCT_UPDATE_STATUS_TOPIC, event);
+        kafkaEventPublisher.publish(PRODUCT_TOPIC, event);
         log.info("상품 상태 수정 이벤트 발행: productCode={}, status={}", product.getCode(), product.getStatus().name());
     }
 

--- a/products/src/main/java/com/ll/products/domain/product/model/entity/ProductDlqEvent.java
+++ b/products/src/main/java/com/ll/products/domain/product/model/entity/ProductDlqEvent.java
@@ -1,0 +1,34 @@
+package com.ll.products.domain.product.model.entity;
+
+import com.ll.core.model.persistence.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "product_dlq_event")
+public class ProductDlqEvent extends BaseEntity {
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(name = "event_payload", nullable = false, columnDefinition = "TEXT")
+    private String eventPayload;
+
+    @Column(name = "failed_at")
+    private LocalDateTime failedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private DlqStatus status = DlqStatus.PENDING;
+
+}

--- a/products/src/main/java/com/ll/products/domain/product/repository/ProductDlqEventRepository.java
+++ b/products/src/main/java/com/ll/products/domain/product/repository/ProductDlqEventRepository.java
@@ -1,0 +1,7 @@
+package com.ll.products.domain.product.repository;
+
+import com.ll.products.domain.product.model.entity.ProductDlqEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductDlqEventRepository extends JpaRepository<ProductDlqEvent, Long> {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/messaging/consumer/ProductRecommendationEventConsumer.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/messaging/consumer/ProductRecommendationEventConsumer.java
@@ -16,59 +16,27 @@ public class ProductRecommendationEventConsumer {
 
     private final VectorIndexService vectorIndexService;
 
-    private static final String PRODUCT_UPDATE_TOPIC = "product-updated-event";
-    private static final String PRODUCT_DELETE_TOPIC = "product-deleted-event";
-    private static final String PRODUCT_UPDATE_STATUS_TOPIC = "product-updated-status-event";
+    private static final String PRODUCT_TOPIC = "product-event";
     private static final String PRODUCT_GROUP_ID = "product-indexing-group";
 
     @KafkaListener(
-            topics = PRODUCT_UPDATE_TOPIC,
+            topics = PRODUCT_TOPIC,
             groupId = PRODUCT_GROUP_ID
     )
-    public void consumeProductUpdatedEvent(KafkaEventEnvelope<ProductEvent> envelope) {
+    public void consumeProductEvent(KafkaEventEnvelope<ProductEvent> envelope) {
+        ProductEvent event = envelope.payload();
         try {
-            ProductEvent event = envelope.payload();
-            log.info("상품 수정 이벤트 수신: eventType={}, productCode={}", event.eventType(), event.productCode());
+            log.info("상품 이벤트 수신: eventType={}, productCode={}", event.eventType(), event.productCode());
             processEvent(event);
-            log.info("벡터 수정 인덱싱 완료: productCode={}", event.productCode());
+            log.info("벡터 인덱싱 완료: productCode={}", event.productCode());
         } catch (Exception e) {
             log.error("벡터 인덱싱 실패: error={}", e.getMessage(), e);
-            throw new RuntimeException("벡터 수정 인덱싱 중 오류 발생", e);
+            throw new RuntimeException("벡터 인덱싱 중 오류 발생", e);
         }
     }
 
-    @KafkaListener(
-            topics = PRODUCT_DELETE_TOPIC,
-            groupId = PRODUCT_GROUP_ID
-    )
-    public void consumeProductDeletedEvent(KafkaEventEnvelope<ProductEvent> envelope) {
-        try {
-            ProductEvent event = envelope.payload();
-            log.info("상품 삭제 이벤트 수신: eventType={}, productCode={}", event.eventType(), event.productCode());
-            processEvent(event);
-            log.info("벡터 삭제 인덱싱 완료: productCode={}", event.productCode());
-        } catch (Exception e) {
-            log.error("벡터 인덱싱 실패: error={}", e.getMessage(), e);
-            throw new RuntimeException("벡터 삭제 인덱싱 중 오류 발생", e);
-        }
-    }
 
-    @KafkaListener(
-            topics = PRODUCT_UPDATE_STATUS_TOPIC,
-            groupId = PRODUCT_GROUP_ID
-    )
-    public void consumeProductUpdatedStatusEvent(KafkaEventEnvelope<ProductEvent> envelope) {
-        try {
-            ProductEvent event = envelope.payload();
-            log.info("상품 상태 변경 이벤트 수신: eventType={}, productCode={}", event.eventType(), event.productCode());
-            processEvent(event);
-            log.info("벡터 상태 변경 인덱싱 완료: productCode={}", event.productCode());
-        } catch (Exception e) {
-            log.error("벡터 인덱싱 실패: error={}", e.getMessage(), e);
-            throw new RuntimeException("벡터 상태 변경 인덱싱 중 오류 발생", e);
-        }
-    }
-
+    // 이벤트 받아 인덱싱
     private void processEvent(ProductEvent event) {
         ProductEventType eventType = event.eventType();
         switch (eventType) {


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
--- 상품 DLQ 이벤트 저장 및 kafka topic 통합
- 상품 수정/삭제 API에 의한 kafka 이벤트 소비 실패 시 발생하는 DLQ를 DB에 저장.
- 기존 메서드별 kafka topic 통합.

🔗 관련 이슈
---[Product][feat] dlq event 저장 및 kafka topic 통합
- 관련 이슈 번호: #196

📋 요구 사항과 구현 내용
---상품 이벤트 실패 내역 저장
- 상품 이벤트 소비 실패 시 5번의 재시도 후 dlq 이벤트 생성
- dlq 이벤트 컨슈머로 DLQ 저장
- 관리자가 수동 처리하는 방향(관리자 알람 등 추가 기능 구현 필요)

💬 TODO 리스트
--- 기타 작업
- [ ] 예외 처리
- [ ] 테스트코드 작성

🧠 고려사항
--- 상품 동기화 실패 시 롤백?
- 벡터db 동기화가 실패했다고 해서 메인 db까지 영향을 끼쳐선 안됨(롤백 x)
- 5번의 재시도 이후 dlq 발송하므로 같은 재시도를 반복하여도 동일한 오류일 가능성
- dlq 발송 시 관리자 알림 발송하여 관리자가 직접 수동으로 문제 해결하는 방법으로 고려





<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Product 이벤트 토픽 통합 및 인프라 스크립트 정리 
 - infra/scripts/00-env.sh의 Kafka 토픽 설정에서 product 관련 6개 토픽을 제거하고 `product-event`, `product-event.dlq` 2개 토픽으로 통합 
 - `ProductEventProducer`를 `product.event` 패키지에서 `product.messaging.producer` 패키지로 이동해 메시징 레이어로 역할 명확화 
 - `ProductEventProducer`가 사용하던 개별 토픽 상수를 제거하고, 모든 상품 이벤트를 단일 `PRODUCT_TOPIC = "product-event"`로 발행하도록 변경 

2. Product 추천 컨슈머 구조 단일화 (`ProductRecommendationEventConsumer`) 
 - `PRODUCT_UPDATE_TOPIC`, `PRODUCT_DELETE_TOPIC`, `PRODUCT_UPDATE_STATUS_TOPIC`를 제거하고 `PRODUCT_TOPIC = "product-event"` 하나만 사용 
 - 세 개의 `@KafkaListener` 메서드를 `consumeProductEvent` 하나로 통합하고, `ProductEventType`에 따라 `processEvent`에서 분기 처리 
 - 로그 메시지를 단일 이벤트 처리에 맞게 “상품 이벤트 수신”, “벡터 인덱싱 완료” 등으로 정리하고, 예외 메시지도 공통 문구로 단순화 

3. Product DLQ 처리 인프라 추가 
 - `ProductDlqEvent` 엔티티 및 `product_dlq_event` 테이블 매핑 추가: topic, eventPayload(TEXT), failedAt, status(DlqStatus) 필드 정의 
 - `ProductDlqEventRepository`를 추가해 DLQ 이벤트를 JPA로 영속화 가능하도록 구현 
 - `ProductEventDlqConsumer` 신규 추가: 
 - `product-event.dlq` 토픽, `product-dlq-group` 그룹으로 `@KafkaListener` 등록 
 - 수신한 `ConsumerRecord`를 JSON 문자열로 직렬화해 `ProductDlqEvent`로 저장하고, 저장 성공/실패 로그를 기록 
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [Kafka 토픽 이름 변경에 따른 호환성/운영 중단 가능성]
 - [x] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: infra/scripts/00-env.sh, ProductEventProducer, ProductRecommendationEventConsumer 등에서 기존 개별 토픽(product-updated-event, product-deleted-event, product-updated-status-event / *.dlq)을 제거하고 단일 토픽(product-event / product-event.dlq)으로 변경했음.
 - 결과: 기존 환경(프로덕션/스테이징)의 Kafka 브로커나 다른 서비스들이 여전히 구 토픽을 사용/구독하고 있다면, 이벤트 미발행·미소비가 발생하여 상품 변경/삭제/상태변경 이벤트 파이프라인이 중단될 수 있음.
 - 위험성: 토픽 생성/운영 설정이 함께 변경되지 않았거나, 다른 마이크로서비스/컨슈머 코드가 아직 구 토픽만 구독 중인 경우, 서비스 간 데이터 동기화 실패 및 기능 장애(검색/추천/외부 시스템 연동 등)가 실제로 발생할 수 있음.

2. [ProductEventListener import 경로 변경에 따른 컴파일 오류 가능성]
 - [x] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: ProductEventProducer 클래스의 패키지를 com.ll.products.domain.product.event 에서 com.ll.products.domain.product.messaging.producer 로 변경했으나, ProductEventListener.java에서는 import만 추가되고 해당 타입 사용 여부/코드 수정이 diff에 나타나지 않음.
 - 결과: ProductEventListener가 여전히 이전 패키지의 ProductEventProducer를 참조하거나, import 정리가 되지 않은 상태라면 컴파일 에러 또는 사용하지 않는 import 경고가 발생할 수 있음.
 - 위험성: 현재 diff에 ProductEventListener의 본문이 보이지 않아 실제로 컴파일이 깨지는지 여부는 판단 불가이나, 패키지 변경 시 참조 정리 누락은 빌드 실패로 직결될 수 있는 변경임.

3. [잠정적 문제 가능성 – DLQ Consumer 직렬화/역직렬화 처리]
 - [x] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: ProductEventDlqConsumer.consumeDlqEvent에서 ConsumerRecord<String, Object>를 받아 record.value()를 그대로 ObjectMapper.writeValueAsString(...)에 넘김. 실제 DLQ에 저장되는 value 타입/직렬화 포맷은 diff에서 확인 불가.
 - 결과: DLQ 토픽에 저장되는 메시지 값이 이미 String이거나, Jackson이 처리할 수 없는 타입/바이너리일 경우 JsonProcessingException이 발생해 DLQ 이벤트가 DB에 저장되지 않을 수 있음.
 - 위험성: DLQ는 장애 상황 추적의 마지막 수단이므로, 직렬화 설정 불일치 시 장애 원인 분석 데이터가 누락될 수 있음. 다만 DLQ 메시지 포맷과 컨슈머 설정이 diff에 없으므로 실제 발생 여부는 판단 불가. 
 - 파일명: products/src/main/java/com/ll/products/domain/product/messaging/consumer/ProductEventDlqConsumer.java
 ```java
 private ProductDlqEvent buildDlqEvent(ConsumerRecord<String, Object> record) throws JsonProcessingException {
 String eventPayload = objectMapper.writeValueAsString(record.value());
 }
 ```
<!-- AI-REVIEW:END -->