### PR TITLE
[fix][205] Event 객체 core 로 이동

### DIFF
--- a/core/src/main/java/com/ll/core/model/vo/kafka/PaymentRefundNotificationEvent.java
+++ b/core/src/main/java/com/ll/core/model/vo/kafka/PaymentRefundNotificationEvent.java
@@ -1,4 +1,4 @@
-package com.ll.order.domain.model.vo;
+package com.ll.core.model.vo.kafka;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/core/src/main/java/com/ll/core/model/vo/kafka/PaymentRefundRequestEvent.java
+++ b/core/src/main/java/com/ll/core/model/vo/kafka/PaymentRefundRequestEvent.java
@@ -1,4 +1,4 @@
-package com.ll.order.domain.model.vo;
+package com.ll.core.model.vo.kafka;
 
 import jakarta.validation.constraints.*;
 

--- a/order/src/main/java/com/ll/order/domain/messaging/consumer/PaymentEventConsumer.java
+++ b/order/src/main/java/com/ll/order/domain/messaging/consumer/PaymentEventConsumer.java
@@ -1,7 +1,7 @@
 package com.ll.order.domain.messaging.consumer;
 
 import com.ll.core.model.vo.kafka.KafkaEventEnvelope;
-import com.ll.order.domain.model.vo.PaymentRefundNotificationEvent;
+import com.ll.core.model.vo.kafka.PaymentRefundNotificationEvent;
 import com.ll.order.domain.service.order.OrderService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/order/src/main/java/com/ll/order/domain/messaging/producer/OrderEventProducer.java
+++ b/order/src/main/java/com/ll/order/domain/messaging/producer/OrderEventProducer.java
@@ -5,7 +5,7 @@ import com.ll.core.config.kafka.KafkaEventPublisher;
 import com.ll.core.model.vo.kafka.InventoryEvent;
 import com.ll.core.model.vo.kafka.OrderEvent;
 import com.ll.core.model.vo.kafka.RefundEvent;
-import com.ll.order.domain.model.vo.PaymentRefundRequestEvent;
+import com.ll.core.model.vo.kafka.PaymentRefundRequestEvent;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/order/src/main/java/com/ll/order/domain/model/entity/event/PaymentRefundEventOutbox.java
+++ b/order/src/main/java/com/ll/order/domain/model/entity/event/PaymentRefundEventOutbox.java
@@ -2,7 +2,7 @@ package com.ll.order.domain.model.entity.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.core.model.persistence.BaseEntity;
-import com.ll.order.domain.model.vo.PaymentRefundRequestEvent;
+import com.ll.core.model.vo.kafka.PaymentRefundRequestEvent;
 import com.ll.order.domain.model.enums.order.OutboxStatus;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/order/src/main/java/com/ll/order/domain/service/compensation/CompensationRetryService.java
+++ b/order/src/main/java/com/ll/order/domain/service/compensation/CompensationRetryService.java
@@ -7,7 +7,7 @@ import com.ll.order.domain.model.entity.OrderItem;
 import com.ll.order.domain.model.entity.TransactionTracing;
 import com.ll.order.domain.model.enums.transaction.CompensationStatus;
 import com.ll.order.domain.model.enums.order.OrderStatus;
-import com.ll.order.domain.model.vo.PaymentRefundRequestEvent;
+import com.ll.core.model.vo.kafka.PaymentRefundRequestEvent;
 import com.ll.order.domain.repository.OrderItemJpaRepository;
 import com.ll.order.domain.repository.OrderJpaRepository;
 import com.ll.order.domain.repository.TransactionTracingRepository;

--- a/order/src/main/java/com/ll/order/domain/service/event/PaymentRefundRequestEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/PaymentRefundRequestEventOutboxService.java
@@ -2,7 +2,7 @@ package com.ll.order.domain.service.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ll.order.domain.model.vo.PaymentRefundRequestEvent;
+import com.ll.core.model.vo.kafka.PaymentRefundRequestEvent;
 import com.ll.order.domain.model.entity.event.PaymentRefundEventOutbox;
 import com.ll.order.domain.messaging.producer.OrderEventProducer;
 import com.ll.order.domain.model.enums.order.OutboxStatus;

--- a/order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
+++ b/order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
@@ -2,7 +2,7 @@ package com.ll.order.domain.service.order;
 
 import com.ll.core.model.exception.BaseException;
 import com.ll.core.model.vo.kafka.RefundEvent;
-import com.ll.order.domain.model.vo.PaymentRefundRequestEvent;
+import com.ll.core.model.vo.kafka.PaymentRefundRequestEvent;
 import com.ll.order.domain.client.PaymentServiceClient;
 import com.ll.order.domain.client.ProductServiceClient;
 import com.ll.order.domain.client.UserServiceClient;


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Event 객체 core 로 이동

🔗 관련 이슈
---
- 관련 이슈 번호: #205

📋 요구 사항과 구현 내용
---
- Event 객체 core 로 이동

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. PaymentRefund*Event VO의 core 모듈로 이동 및 공통화 
 - `PaymentRefundNotificationEvent` 패키지/경로를 `order` → `core.model.vo.kafka`로 변경 
 - `PaymentRefundRequestEvent` 패키지/경로를 `order` → `core.model.vo.kafka`로 변경 
 - Kafka 관련 VO를 `core` 모듈에 위치시켜 공통 메시지 모델로 활용하도록 구조 정리 

2. order 도메인 내 PaymentRefund*Event 참조 경로 정리 
 - `PaymentEventConsumer`에서 `PaymentRefundNotificationEvent`를 `com.ll.core.model.vo.kafka` 경로로 수정 
 - `OrderEventProducer`, `PaymentRefundEventOutbox`, `CompensationRetryService`, `PaymentRefundRequestEventOutboxService`, `OrderServiceImpl`에서 
 `PaymentRefundRequestEvent` import를 모두 `com.ll.core.model.vo.kafka.PaymentRefundRequestEvent`로 변경 
 - 주문 도메인 전역에서 환불 이벤트 VO를 core 모듈 정의로 일원화하여 의존성 정리
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [공유 VO 패키지 변경에 따른 클래스 참조 불일치 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: PaymentRefundNotificationEvent, PaymentRefundRequestEvent의 패키지가 `com.ll.order.domain.model.vo`에서 `com.ll.core.model.vo.kafka`로 변경되었고, order 모듈 내 여러 클래스의 import를 이에 맞게 수정했으나, diff 상에서 이 VO들을 사용하는 모든 파일이 누락 없이 수정되었는지는 확인 불가.
 - 결과: 일부 코드가 여전히 `com.ll.order.domain.model.vo.PaymentRefund*`를 참조하고 있을 경우, 컴파일 오류(Class not found)가 발생해 빌드가 실패하고 서비스 배포가 중단될 수 있음.
 - 위험성: 현재 diff에 나온 파일들은 일관되게 수정되었으나, 다른 레이어(예: test 코드, 기타 service/consumer/producer)에서 구 패키지를 참조하는 사용처가 남아있다면 빌드 자체가 깨지는 치명적 문제로 이어짐.

---

[잠정적 문제 가능성]

1. [모듈 간 의존성/순환참조 위험 (order → core 이동)]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: PaymentRefund* 이벤트 VO를 order 모듈에서 core 모듈로 이동시키면서 패키지를 `com.ll.core.model.vo.kafka`로 변경했으나, core 모듈과 order 모듈 간 의존 관계 구조는 diff에서 확인 불가.
 - 결과: core 모듈이 order 모듈에 의존하거나, 양방향 의존이 발생하는 구조라면, 컴파일/런타임 시 순환 의존성 문제 또는 모듈 분리 원칙 위반이 발생할 수 있음.
 - 위험성: 현재 diff만으로는 실제 순환 의존 여부를 단정할 수 없지만, 공용 VO를 core로 승격하는 변경은 빌드/배포 전 모듈 의존성 다이어그램 재점검이 필요할 정도로 잠재적 영향을 가짐.
<!-- AI-REVIEW:END -->