### PR TITLE
[docs][211] ChargeDepositApiResponse 의 Swagger 일부 수정

### DIFF
--- a/payment/src/main/java/com/ll/payment/deposit/controller/swagger/ChargeDepositApiResponse.java
+++ b/payment/src/main/java/com/ll/payment/deposit/controller/swagger/ChargeDepositApiResponse.java
@@ -87,6 +87,17 @@ import java.lang.annotation.*;
                                                 """
                                 ),
                                 @ExampleObject(
+                                        name = "400 - X-User-Code 공란",
+                                        description = "필수 헤더 누락 또는 요청 형식이 잘못된 경우의 응답 예시입니다.",
+                                        value = """
+                                                    {
+                                                        "status": 400,
+                                                        "message": "userCode 는 공백이거나 null일 수 없습니다.",
+                                                        "errorCode": "BAD_REQUEST"
+                                                    }
+                                                """
+                                ),
+                                @ExampleObject(
                                         name = "400 - amount 누락",
                                         description = "필수 헤더 누락 또는 요청 형식이 잘못된 경우의 응답 예시입니다.",
                                         value = """


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- ChargeDepositApiResponse 의 Swagger 일부 수정

🔗 관련 이슈
---
- 관련 이슈 번호: #211

📋 요구 사항과 구현 내용
---
- - ChargeDepositApiResponse 의 Swagger 일부 수정

💬 TODO 리스트
---
- [ ] ChargeDepositApiResponse 의 Swagger 일부 수정

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. ChargeDepositApiResponse 400 에러 예시 추가 
 - `ChargeDepositApiResponse`의 Swagger 문서에 `@ExampleObject` 항목을 추가함 
 - `name = "400 - X-User-Code 공란"`으로, X-User-Code 헤더가 공란/null인 경우의 응답 예시를 명시 
 - 예시 응답으로 `status: 400`, `message: "userCode 는 공백이거나 null일 수 없습니다."`, `errorCode: "BAD_REQUEST"`를 제공해 잘못된 요청 케이스를 구체적으로 문서화함
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. 문서 스펙과 실제 동작 불일치 가능성 (잠정적 문제 가능성)
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: Swagger 예제에 `400 - X-User-Code 공란` 응답이 추가되었으나, 해당 헤더 검증 로직 및 실제 에러 메시지/코드가 서버 구현과 일치하는지 여부는 diff에서 확인 불가.
 - 결과: 문서 상으로는 `userCode` 공란/누락 시 400과 특정 메시지(`userCode 는 공백이거나 null일 수 없습니다.`) 및 `BAD_REQUEST` 에러코드를 기대하게 되지만, 실제 응답 형식이 다를 경우 클라이언트 구현·에러 처리 로직과 불일치 발생 가능.
 - 위험성: API 스펙과 실제 동작이 불일치하면 클라이언트 측 예외 처리 실패, 잘못된 사용자 안내, 연계 시스템 간 장애를 유발할 수 있으나, 현재 diff만으로 실제 불일치 여부는 판단 불가.

해당 diff는 컴파일 오류, 즉각적인 런타임 오류, 보안 취약점 등을 직접 유발하는 변경은 포함하지 않으므로, 치명적 확정 문제로 분류할 항목은 없습니다.
<!-- AI-REVIEW:END -->