### PR TITLE
[refactor][213] Deposit 필요없는 엔드포인트 삭제

### DIFF
--- a/payment/src/main/java/com/ll/payment/deposit/controller/DepositController.java
+++ b/payment/src/main/java/com/ll/payment/deposit/controller/DepositController.java
@@ -4,17 +4,16 @@ import com.ll.core.model.response.BaseResponse;
 import com.ll.core.model.vo.common.DateRange;
 import com.ll.payment.deposit.controller.swagger.*;
 import com.ll.payment.deposit.model.vo.request.DepositDeleteRequest;
-import com.ll.payment.deposit.model.vo.request.DepositTransactionRequest;
 import com.ll.payment.deposit.model.vo.response.DepositDeleteResponse;
 import com.ll.payment.deposit.model.vo.response.DepositHistoryPageResponse;
 import com.ll.payment.deposit.model.vo.response.DepositResponse;
-import com.ll.payment.deposit.model.vo.response.DepositTransactionResponse;
 import com.ll.payment.deposit.service.DepositService;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/deposits")
+@Profile("prod")
 public class DepositController {
     private final DepositService depositService;
 
@@ -35,64 +35,6 @@ public class DepositController {
 
     ) {
         return BaseResponse.ok(depositService.getDepositByUserCode(userCode));
-    }
-
-    @PostMapping
-    @CreateDepositApiResponse
-    public ResponseEntity<BaseResponse<DepositResponse>> createDeposit(
-            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
-            @RequestHeader(value = "X-User-Code")
-            String userCode
-    ) {
-        return BaseResponse.created(depositService.createDeposit(userCode));
-    }
-
-    @PostMapping("/charge")
-    @ChargeDepositApiResponse
-    public ResponseEntity<BaseResponse<DepositTransactionResponse>> chargeDeposit(
-            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
-            @RequestHeader(value = "X-User-Code")
-            String userCode,
-            @Parameter(hidden = true)
-            @Valid @RequestBody DepositTransactionRequest request
-    ) {
-        return BaseResponse.ok(depositService.chargeDeposit(userCode, request));
-    }
-
-    @PostMapping("/withdraw")
-    @WithdrawDepositApiResponse
-    public ResponseEntity<BaseResponse<DepositTransactionResponse>> withdrawDeposit(
-            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
-            @RequestHeader(value = "X-User-Code")
-            String userCode,
-            @Parameter(hidden = true)
-            @Valid @RequestBody DepositTransactionRequest request
-    ) {
-        return BaseResponse.ok(depositService.withdrawDeposit(userCode, request));
-    }
-
-    @PostMapping("/payment")
-    @PaymentDepositApiResponse
-    public ResponseEntity<BaseResponse<DepositTransactionResponse>> paymentDeposit(
-            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
-            @RequestHeader(value = "X-User-Code")
-            String userCode,
-            @Parameter(hidden = true)
-            @Valid @RequestBody DepositTransactionRequest request
-    ) {
-        return BaseResponse.ok(depositService.paymentDeposit(userCode, request));
-    }
-
-    @PostMapping("/refund")
-    @RefundDepositApiResponse
-    public ResponseEntity<BaseResponse<DepositTransactionResponse>> refundDeposit(
-            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
-            @RequestHeader(value = "X-User-Code")
-            String userCode,
-            @Parameter(hidden = true)
-            @Valid @RequestBody DepositTransactionRequest request
-    ) {
-        return BaseResponse.ok(depositService.refundDeposit(userCode, request));
     }
 
     @PatchMapping("/close")

--- a/payment/src/main/java/com/ll/payment/deposit/controller/DepositDevController.java
+++ b/payment/src/main/java/com/ll/payment/deposit/controller/DepositDevController.java
@@ -1,0 +1,127 @@
+package com.ll.payment.deposit.controller;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.core.model.vo.common.DateRange;
+import com.ll.payment.deposit.controller.swagger.*;
+import com.ll.payment.deposit.model.vo.request.DepositDeleteRequest;
+import com.ll.payment.deposit.model.vo.request.DepositTransactionRequest;
+import com.ll.payment.deposit.model.vo.response.DepositDeleteResponse;
+import com.ll.payment.deposit.model.vo.response.DepositHistoryPageResponse;
+import com.ll.payment.deposit.model.vo.response.DepositResponse;
+import com.ll.payment.deposit.model.vo.response.DepositTransactionResponse;
+import com.ll.payment.deposit.service.DepositService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Deposit", description = "예치금 관리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/deposits")
+@Profile("!prod")
+public class DepositDevController {
+    private final DepositService depositService;
+
+    @GetMapping
+    @GetDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositResponse>> getDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode
+
+    ) {
+        return BaseResponse.ok(depositService.getDepositByUserCode(userCode));
+    }
+
+    @PostMapping
+    @CreateDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositResponse>> createDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode
+    ) {
+        return BaseResponse.created(depositService.createDeposit(userCode));
+    }
+
+    @PostMapping("/charge")
+    @ChargeDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositTransactionResponse>> chargeDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode,
+            @Parameter(hidden = true)
+            @Valid @RequestBody DepositTransactionRequest request
+    ) {
+        return BaseResponse.ok(depositService.chargeDeposit(userCode, request));
+    }
+
+    @PostMapping("/withdraw")
+    @WithdrawDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositTransactionResponse>> withdrawDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode,
+            @Parameter(hidden = true)
+            @Valid @RequestBody DepositTransactionRequest request
+    ) {
+        return BaseResponse.ok(depositService.withdrawDeposit(userCode, request));
+    }
+
+    @PostMapping("/payment")
+    @PaymentDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositTransactionResponse>> paymentDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode,
+            @Parameter(hidden = true)
+            @Valid @RequestBody DepositTransactionRequest request
+    ) {
+        return BaseResponse.ok(depositService.paymentDeposit(userCode, request));
+    }
+
+    @PostMapping("/refund")
+    @RefundDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositTransactionResponse>> refundDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode,
+            @Parameter(hidden = true)
+            @Valid @RequestBody DepositTransactionRequest request
+    ) {
+        return BaseResponse.ok(depositService.refundDeposit(userCode, request));
+    }
+
+    @PatchMapping("/close")
+    @DeleteDepositApiResponse
+    public ResponseEntity<BaseResponse<DepositDeleteResponse>> deleteDeposit(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode,
+            @Parameter(hidden = true)
+            @Valid @RequestBody DepositDeleteRequest request
+    ) {
+        return BaseResponse.ok(depositService.deleteDepositByUserCode(userCode, request));
+    }
+
+    @GetMapping("/histories")
+    @GetDepositHistoryApiResponse
+    public ResponseEntity<BaseResponse<DepositHistoryPageResponse>> getDepositHistories(
+            @NotBlank(message = "userCode 는 공백이거나 null일 수 없습니다.")
+            @RequestHeader(value = "X-User-Code")
+            String userCode,
+            @Parameter(hidden = true)
+            @Valid @ModelAttribute DateRange dateRange,
+            @Parameter(hidden = true)
+            Pageable pageable
+    ) {
+        dateRange.validate();
+        return BaseResponse.ok(depositService.getDepositHistoryByUserCode(userCode, dateRange.getStartDateTime(), dateRange.getEndDateTime(), pageable));
+    }
+
+}

--- a/payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentServiceImpl.java
+++ b/payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentServiceImpl.java
@@ -119,7 +119,7 @@ public class DepositPaymentServiceImpl implements DepositPaymentService {
         }
 
         // 2. 예치금 차감 (락 유지 중)
-        depositService.withdrawDeposit(
+        depositService.paymentDeposit(
                 payment.buyerCode(),
                 new DepositTransactionRequest((long) amount, createReferenceCode(payment.orderId()))
         );


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Deposit 필요없는 엔드포인트 삭제

🔗 관련 이슈
---
- 관련 이슈 번호: #213

📋 요구 사항과 구현 내용
---
- dev 용 Controller 생성
- prod 용 Controller 에서 필요없는 엔드포인트 삭제
- DepositPaymentServiceImpl 에서 withdrawDeposit -> paymentDeposit 변경

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. DepositController 프로덕션 전용 분리 
 - `DepositController`에 `@Profile("prod")` 추가하여 프로덕션 환경에만 활성화 
 - 기존에 포함되어 있던 `createDeposit`, `/charge`, `/withdraw`, `/payment`, `/refund` POST 메서드 제거 
 - 불필요해진 `DepositTransactionRequest`, `DepositTransactionResponse` import 제거로 의존성 정리 

2. 개발·비프로덕션용 DepositDevController 신설 
 - `@Profile("!prod")`가 적용된 `DepositDevController` 신규 추가, 경로는 동일하게 `/api/deposits` 사용 
 - `getDeposit`, `createDeposit`, `/charge`, `/withdraw`, `/payment`, `/refund`, `/close`, `/histories` 등 예치금 전 기능을 비프로덕션에서만 제공 
 - `DepositService`를 그대로 사용하며, 기존 DepositController에 있던 로직을 대부분 이 컨트롤러로 이동 

3. 예치금 결제 로직에서 메서드 사용 변경 
 - `DepositPaymentServiceImpl.completeDepositPayment`에서 예치금 차감 시 `depositService.withdrawDeposit` 대신 `depositService.paymentDeposit` 호출로 변경 
 - 동일한 `DepositTransactionRequest`를 사용하되, 결제 상황에 맞는 서비스 메서드를 명시적으로 사용하도록 수정
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. prod 환경에서 예치금 관련 POST API 비활성화로 인한 기능 중단
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: DepositController에 `@Profile("prod")`가 추가되면서, 기존 POST 엔드포인트들(create/charge/withdraw/payment/refund)이 삭제되고, 동일 기능을 가진 DepositDevController가 `@Profile("!prod")`로만 활성화되도록 분리됨.
 - 결과: prod 프로필에서는 `/api/deposits`, `/api/deposits/charge`, `/withdraw`, `/payment`, `/refund` 등의 예치금 변경용 API가 더 이상 매핑되지 않아 404/메서드 미지원이 발생함.
 - 위험성: 운영 환경에서 예치금 생성·충전·출금·결제·환불이 모두 불가능해져 서비스 핵심 결제/예치금 기능이 전면 중단될 수 있음.

2. DepositPaymentServiceImpl의 메서드 변경으로 인한 로직 불일치/실패 가능성
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: 예치금 결제 완료 처리에서 `depositService.withdrawDeposit(...)` 호출이 `depositService.paymentDeposit(...)` 호출로 변경됨.
 - 결과: `paymentDeposit` 메서드 시그니처 및 내부 구현이 기존 출금/차감 로직과 동일하게 동작하지 않거나, 예치금 결제 처리의 도메인 규칙(잔액 차감 방식, 이력 타입, 상태값 등)과 달라질 수 있음.
 - 위험성: 실제로 출금이 되지 않거나, 잘못된 타입의 거래 이력이 생성되는 등 결제 처리와 예치금 잔액/이력이 불일치하여 데이터 무결성 문제가 발생할 수 있음.

3. 판단 불가 – DepositPaymentServiceImpl와 DepositService 간 계약(시그니처/도메인 규칙) 불일치 가능성
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: diff 내에서 DepositService 인터페이스/구현체 및 `paymentDeposit` 메서드 정의는 보이지 않고, 호출부만 `withdrawDeposit` → `paymentDeposit` 으로 변경됨.
 - 결과: 만약 DepositService에 `paymentDeposit(String, DepositTransactionRequest)`가 없거나, 예외를 던지거나, 입금/충전용 메서드로 구현되어 있다면, 컴파일 에러 혹은 런타임 시 예치금 처리 오동작이 발생할 수 있음.
 - 위험성: 실제 구현을 확인할 수 없어 확정적 판단은 불가하지만, 현재 변경만 보면 결제 시 예치금 차감이 정상적으로 이뤄지지 않을 잠정적 위험이 있음.

문제 원인 코드 예시:
- 파일명: `payment/src/main/java/com/ll/payment/deposit/controller/DepositController.java`
```java
@RequestMapping("/api/deposits")
@Profile("prod")
public class DepositController {
 // 기존 create/charge/withdraw/payment/refund 메서드 전체 삭제됨
}
```

- 파일명: `payment/src/main/java/com/ll/payment/deposit/controller/DepositDevController.java`
```java
@RequestMapping("/api/deposits")
@Profile("!prod")
public class DepositDevController {
 // create/charge/withdraw/payment/refund 포함 모든 예치금 변경 API가 비-prod에서만 활성화
}
```

- 파일명: `payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentServiceImpl.java`
```java
// before
depositService.withdrawDeposit(
 payment.buyerCode(),
 new DepositTransactionRequest((long) amount, createReferenceCode(payment.orderId()))
);

// after
depositService.paymentDeposit(
 payment.buyerCode(),
 new DepositTransactionRequest((long) amount, createReferenceCode(payment.orderId()))
);
```
<!-- AI-REVIEW:END -->