### PR TITLE
[refactor][216] 동시성 테스트 결과 로그, 락 적용 로그 추가 

### DIFF
--- a/order/src/main/java/com/ll/order/domain/mock/controller/CartMockController.java
+++ b/order/src/main/java/com/ll/order/domain/mock/controller/CartMockController.java
@@ -12,20 +12,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-/**
- * Cart Service Mock Controller
- * 로컬 개발 환경에서 장바구니 정보를 모킹하는 컨트롤러
- */
 @Slf4j
 @RestController
 @RequestMapping("/api/carts")
 public class CartMockController {
 
-    /**
-     * 장바구니 조회 Mock API
-     * GET /api/carts/cartItems
-     * Header: X-User-Code
-     */
     @GetMapping("/cartItems")
     public ResponseEntity<BaseResponse<CartItemsResponse>> getCartItems(
             @RequestHeader("X-User-Code") String userCode

--- a/order/src/main/java/com/ll/order/domain/mock/controller/PaymentMockController.java
+++ b/order/src/main/java/com/ll/order/domain/mock/controller/PaymentMockController.java
@@ -7,19 +7,10 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
-/**
- * Payment Service Mock Controller
- * 로컬 개발 환경에서 결제 정보를 모킹하는 컨트롤러
- */
 @Slf4j
 @RestController
 @RequestMapping("/api/payments")
 public class PaymentMockController {
-
-    /**
-     * 예치금 결제 Mock API
-     * POST /api/payments/deposit
-     */
     @PostMapping("/deposit")
     public ResponseEntity<String> requestDepositPayment(
             @RequestBody OrderPaymentRequest request
@@ -31,11 +22,6 @@ public class PaymentMockController {
         log.info("Mock Payment Service - 예치금 결제 성공: orderCode={}", request.orderCode());
         return ResponseEntity.ok("결제 완료");
     }
-
-    /**
-     * 토스 결제 Mock API
-     * POST /api/payments/toss
-     */
     @PostMapping("/toss")
     public ResponseEntity<String> requestTossPayment(
             @RequestBody OrderPaymentRequest request
@@ -48,10 +34,6 @@ public class PaymentMockController {
         return ResponseEntity.ok("결제 완료");
     }
 
-    /**
-     * 환불 Mock API
-     * POST /api/payments/refund
-     */
     @PostMapping("/refund")
     public ResponseEntity<String> requestRefund(
             @RequestBody Map<String, Object> request

--- a/order/src/main/java/com/ll/order/domain/mock/controller/ProductMockController.java
+++ b/order/src/main/java/com/ll/order/domain/mock/controller/ProductMockController.java
@@ -1,10 +1,13 @@
 package com.ll.order.domain.mock.controller;
 
 import com.ll.core.model.response.BaseResponse;
+import com.ll.order.domain.client.ProductServiceClient;
 import com.ll.order.domain.model.enums.product.ProductStatus;
 import com.ll.order.domain.model.vo.response.product.ProductImageDto;
 import com.ll.order.domain.model.vo.response.product.ProductResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,19 +15,17 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Product Service Mock Controller
- * 로컬 개발 환경에서 상품 정보를 모킹하는 컨트롤러
- */
 @Slf4j
 @RestController
 @RequestMapping("/api/products")
+@RequiredArgsConstructor
 public class ProductMockController {
 
-    /**
-     * 상품 정보 조회 Mock API
-     * GET /api/products/{productCode}
-     */
+    private final ProductServiceClient productServiceClient;
+
+    @Value("${external.product-service.url:http://localhost:8085}")
+    private String productServiceUrl;
+
     @GetMapping("/{productCode}")
     public ResponseEntity<BaseResponse<ProductResponse>> getProduct(
             @PathVariable String productCode
@@ -65,28 +66,32 @@ public class ProductMockController {
         return BaseResponse.error(com.ll.core.model.exception.ErrorCode.NOT_FOUND);
     }
 
-    /**
-     * 재고 차감 Mock API
-     * PATCH /api/products/{productCode}/inventory
-     * Body: { "quantity": -2 } (음수로 전달하여 차감)
-     */
     @PatchMapping("/{productCode}/inventory")
     public ResponseEntity<Void> decreaseInventory(
             @PathVariable String productCode,
             @RequestBody Map<String, Integer> request
     ) {
         Integer quantity = request.get("quantity");
-        log.info("Mock Product Service - 재고 차감 요청: productCode={}, quantity={}", productCode, quantity);
+        log.info("========== Mock Product Service - 재고 차감 요청 ==========");
+        log.info("productCode: {}, quantity: {}", productCode, quantity);
+        log.info("실제 Product 서비스 호출 시작 (락 쿼리 실행 확인)");
+        log.info("Product 서비스 URL: {}", productServiceUrl);
 
-        // PROD-001에 대한 재고 차감 처리 (실제로는 아무것도 하지 않음)
-        if ("PROD-001".equals(productCode)) {
-            log.info("Mock Product Service - 재고 차감 성공: productCode={}, quantity={}", productCode, quantity);
+        try {
+            // 실제 ProductServiceClient를 통해 실제 Product 서비스 호출 -> 락 쿼리 적용
+            productServiceClient.decreaseInventory(productCode, quantity);
+            
+            log.info("========== Mock Product Service - 재고 차감 성공 ==========");
+            log.info("productCode: {}, quantity: {}", productCode, quantity);
+            log.info("실제 Product 서비스에서 락 쿼리 실행 완료");
+            log.info("ProductRepository.findByCodeWithLock() -> PESSIMISTIC_WRITE 락 적용됨");
             return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            log.error("========== Mock Product Service - 재고 차감 실패 ==========");
+            log.error("productCode: {}, quantity: {}", productCode, quantity);
+            log.error("실제 Product 서비스 호출 실패: {}", e.getMessage(), e);
+            throw e;
         }
-
-        // 존재하지 않는 상품
-        log.warn("Mock Product Service - 상품을 찾을 수 없음: productCode={}", productCode);
-        return ResponseEntity.notFound().build();
     }
 }
 

--- a/order/src/main/java/com/ll/order/domain/mock/controller/ProductMockController.java
+++ b/order/src/main/java/com/ll/order/domain/mock/controller/ProductMockController.java
@@ -18,13 +18,7 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/api/products")
-@RequiredArgsConstructor
 public class ProductMockController {
-
-    private final ProductServiceClient productServiceClient;
-
-    @Value("${external.product-service.url:http://localhost:8085}")
-    private String productServiceUrl;
 
     @GetMapping("/{productCode}")
     public ResponseEntity<BaseResponse<ProductResponse>> getProduct(
@@ -72,26 +66,17 @@ public class ProductMockController {
             @RequestBody Map<String, Integer> request
     ) {
         Integer quantity = request.get("quantity");
-        log.info("========== Mock Product Service - 재고 차감 요청 ==========");
-        log.info("productCode: {}, quantity: {}", productCode, quantity);
-        log.info("실제 Product 서비스 호출 시작 (락 쿼리 실행 확인)");
-        log.info("Product 서비스 URL: {}", productServiceUrl);
+        log.info("Mock Product Service - 재고 차감 요청: productCode={}, quantity={}", productCode, quantity);
 
-        try {
-            // 실제 ProductServiceClient를 통해 실제 Product 서비스 호출 -> 락 쿼리 적용
-            productServiceClient.decreaseInventory(productCode, quantity);
-            
-            log.info("========== Mock Product Service - 재고 차감 성공 ==========");
-            log.info("productCode: {}, quantity: {}", productCode, quantity);
-            log.info("실제 Product 서비스에서 락 쿼리 실행 완료");
-            log.info("ProductRepository.findByCodeWithLock() -> PESSIMISTIC_WRITE 락 적용됨");
+        // PROD-001에 대한 재고 차감 처리 (실제로는 아무것도 하지 않음)
+        if ("PROD-001".equals(productCode)) {
+            log.info("Mock Product Service - 재고 차감 성공: productCode={}, quantity={}", productCode, quantity);
             return ResponseEntity.ok().build();
-        } catch (Exception e) {
-            log.error("========== Mock Product Service - 재고 차감 실패 ==========");
-            log.error("productCode: {}, quantity: {}", productCode, quantity);
-            log.error("실제 Product 서비스 호출 실패: {}", e.getMessage(), e);
-            throw e;
         }
-    }
+
+        // 존재하지 않는 상품
+        log.warn("Mock Product Service - 상품을 찾을 수 없음: productCode={}", productCode);
+        return ResponseEntity.notFound().build();
+    }       
 }
 

--- a/order/src/main/java/com/ll/order/domain/mock/controller/ProductMockController.java
+++ b/order/src/main/java/com/ll/order/domain/mock/controller/ProductMockController.java
@@ -77,6 +77,6 @@ public class ProductMockController {
         // 존재하지 않는 상품
         log.warn("Mock Product Service - 상품을 찾을 수 없음: productCode={}", productCode);
         return ResponseEntity.notFound().build();
-    }       
+    }
 }
 

--- a/order/src/main/java/com/ll/order/domain/mock/controller/UserMockController.java
+++ b/order/src/main/java/com/ll/order/domain/mock/controller/UserMockController.java
@@ -15,20 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 
-/**
- * User Service Mock Controller
- * 로컬 개발 환경에서 사용자 정보를 모킹하는 컨트롤러
- */
 @Slf4j
 @RestController
 @RequestMapping("/api/users")
 public class UserMockController {
 
-    /**
-     * 사용자 정보 조회 Mock API
-     * GET /api/users/info
-     * Header: X-User-Code
-     */
     @GetMapping("/info")
     public ResponseEntity<BaseResponse<UserResponse>> getUserInfo(
             @RequestHeader("X-User-Code") String userCode

--- a/order/src/test/java/com/ll/order/integration/OrderConcurrencyTest.java
+++ b/order/src/test/java/com/ll/order/integration/OrderConcurrencyTest.java
@@ -1,4 +1,4 @@
-package com.ll.order.integration.failure;
+package com.ll.order.integration;
 
 import com.ll.core.model.exception.BaseException;
 import com.ll.order.domain.mock.controller.ProductMockController;
@@ -14,16 +14,15 @@ import com.ll.order.domain.model.vo.request.OrderDirectRequest;
 import com.ll.order.domain.model.vo.response.order.OrderCreateResponse;
 import com.ll.order.domain.model.vo.response.product.ProductResponse;
 import com.ll.order.domain.model.vo.response.user.UserResponse;
+import com.ll.order.integration.failure.BaseOrderIntegrationFailureTest;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;

--- a/order/src/test/java/com/ll/order/integration/OrderConcurrencyTest.java
+++ b/order/src/test/java/com/ll/order/integration/OrderConcurrencyTest.java
@@ -47,7 +47,7 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
     void setUp() {
         user1 = createTestUser();
 
-    user2 = new UserResponse(
+        user2 = new UserResponse(
                 2L,
                 "USER-002",
                 "test_social_id_2",
@@ -107,28 +107,28 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
         final String[] thread2Name = new String[1];
 
         when(productServiceClient.getProductByCode(productCode)).thenReturn(testProduct);
-        
+
         // 재고 차감 Mock 설정 (실제 재고 상태 기반으로 동시성 테스트)
         doAnswer(invocation -> {
             inventoryDecreaseCallCount.incrementAndGet();
             String calledProductCode = invocation.getArgument(0);
             Integer calledQuantity = invocation.getArgument(1);
-            log.info("[재고 차감 호출 추적 #{}] productCode: {}, quantity: {}", 
+            log.info("[재고 차감 호출 추적 #{}] productCode: {}, quantity: {}",
                     inventoryDecreaseCallCount.get(), calledProductCode, calledQuantity);
-            
+
             // 동시성 제어: 원자적으로 재고 차감 시도
             int current = currentInventory.get();
             int newInventory = current - calledQuantity;
-            
-            log.info("[재고 차감 시도] 현재 재고: {}, 차감 수량: {}, 예상 재고: {}", 
+
+            log.info("[재고 차감 시도] 현재 재고: {}, 차감 수량: {}, 예상 재고: {}",
                     current, calledQuantity, newInventory);
-            
+
             // 재고 부족 체크 및 원자적 업데이트
             if (newInventory < 0) {
                 log.warn("[재고 차감 실패] 재고 부족 - 현재 재고: {}, 요청 수량: {}", current, calledQuantity);
                 throw new RuntimeException("재고 부족: 현재 재고 " + current + "개, 요청 수량 " + calledQuantity + "개");
             }
-            
+
             // 원자적으로 재고 차감
             boolean updated = currentInventory.compareAndSet(current, newInventory);
             if (!updated) {
@@ -136,7 +136,7 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
                 int retryCurrent = currentInventory.get();
                 int retryNewInventory = retryCurrent - calledQuantity;
                 if (retryNewInventory < 0) {
-                    log.warn("[재고 차감 실패] 재고 부족 (재시도) - 현재 재고: {}, 요청 수량: {}", 
+                    log.warn("[재고 차감 실패] 재고 부족 (재시도) - 현재 재고: {}, 요청 수량: {}",
                             retryCurrent, calledQuantity);
                     throw new RuntimeException("재고 부족: 현재 재고 " + retryCurrent + "개, 요청 수량 " + calledQuantity + "개");
                 }
@@ -145,10 +145,10 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
             } else {
                 log.info("[재고 차감 성공] 현재 재고: {} → {}", current, newInventory);
             }
-            
+
             return null;
         }).when(productServiceClient).decreaseInventory(anyString(), anyInt());
-        
+
         // 결제 Mock 설정 (재고 차감 성공한 주문만 결제 진행)
         doAnswer(invocation -> {
             log.info("[결제 처리] 예치금 결제 성공");
@@ -309,14 +309,14 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
 
         // 재고 차감은 2번 호출되어야 함 (두 사용자 모두 재고 차감 시도)
         assertThat(inventoryDecreaseCallCount.get()).isEqualTo(2);
-        
+
         // 최종 재고 확인 (초기 3개 - 성공한 주문 2개 = 1개)
         int finalInventory = currentInventory.get();
         log.info("========== 상품 재고량 확인 ==========");
         log.info("원래 재고량: {}개", originalInventory);
         log.info("동시성 테스트 후 상품 재고량: {}개", finalInventory);
         log.info("재고 차감량: {}개 (성공한 주문 수량)", orderQuantity);
-        log.info("재고 변화: {}개 → {}개 ({}개 차감)", 
+        log.info("재고 변화: {}개 → {}개 ({}개 차감)",
                 originalInventory, finalInventory, originalInventory - finalInventory);
         assertThat(finalInventory)
                 .as("최종 재고는 초기 재고에서 성공한 주문 수량만큼 차감되어야 함")

--- a/order/src/test/java/com/ll/order/integration/failure/OrderConcurrencyTest.java
+++ b/order/src/test/java/com/ll/order/integration/failure/OrderConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.ll.order.integration.failure;
 
 import com.ll.core.model.exception.BaseException;
+import com.ll.order.domain.mock.controller.ProductMockController;
 import com.ll.order.domain.model.entity.Order;
 import com.ll.order.domain.model.enums.order.OrderStatus;
 import com.ll.order.domain.model.enums.order.OrderType;
@@ -17,9 +18,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +37,9 @@ import static org.mockito.Mockito.*;
 @Slf4j
 class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
 
+    @Autowired
+    private ProductMockController productMockController;
+
     private UserResponse user1;
     private UserResponse user2;
     private ProductResponse testProduct;
@@ -41,7 +48,7 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
     void setUp() {
         user1 = createTestUser();
 
-        user2 = new UserResponse(
+    user2 = new UserResponse(
                 2L,
                 "USER-002",
                 "test_social_id_2",
@@ -71,8 +78,10 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
         int orderQuantity = 2; // 각 사용자가 2개씩 주문
 
         log.info("========== 동시성 테스트 시작 ==========");
-        log.info("상품 코드: {}, 초기 재고: {}, 각 사용자 주문 수량: {}",
-                productCode, testProduct.quantity(), orderQuantity);
+        int originalInventory = testProduct.quantity();
+        log.info("상품 코드: {}", productCode);
+        log.info("원래 재고량: {}개", originalInventory);
+        log.info("각 사용자 주문 수량: {}개", orderQuantity);
         log.info("테스트 방식: 실제 재고 상태를 추적하여 동시성 제어 시뮬레이션");
 
         // Mock 설정
@@ -98,38 +107,49 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
         final String[] thread1Name = new String[1];
         final String[] thread2Name = new String[1];
 
-        // Mock 설정: 재고 차감 (실제 재고 상태 기반 동시성 제어)
-        // 비관적 락을 시뮬레이션하여 실제 재고 상태를 기반으로 동작
+        when(productServiceClient.getProductByCode(productCode)).thenReturn(testProduct);
+        
+        // 재고 차감 Mock 설정 (실제 재고 상태 기반으로 동시성 테스트)
         doAnswer(invocation -> {
-            int callCount = inventoryDecreaseCallCount.incrementAndGet();
+            inventoryDecreaseCallCount.incrementAndGet();
             String calledProductCode = invocation.getArgument(0);
             Integer calledQuantity = invocation.getArgument(1);
-
-            log.info("[재고 차감 호출 #{}] productCode: {}, 요청 수량: {}, 현재 재고: {}", 
-                    callCount, calledProductCode, calledQuantity, currentInventory.get());
-
-            // 비관적 락 시뮬레이션: 재고 상태를 원자적으로 확인하고 차감
-            int currentStock = currentInventory.get();
-            int requestedQuantity = calledQuantity;
-
-            log.info("[락 적용] 비관적 락(PESSIMISTIC_WRITE)으로 상품 조회 및 재고 확인 - 현재 재고: {}", currentStock);
-
-            if (currentStock >= requestedQuantity) {
-                // 재고 충분: 차감 성공
-                int newStock = currentInventory.addAndGet(-requestedQuantity);
-                log.info("[재고 차감 성공] 재고 차감 완료 - 차감량: {}, 남은 재고: {} (락 적용됨)", 
-                        requestedQuantity, newStock);
-                return null;
-            } else {
-                // 재고 부족: 차감 실패
-                log.warn("[재고 차감 실패] 재고 부족 - 요청 수량: {}, 현재 재고: {} (락 적용됨)", 
-                        requestedQuantity, currentStock);
-                log.warn("[락 적용] 비관적 락으로 조회했으나 재고가 부족하여 실패");
-                throw new RuntimeException("재고 부족: 요청 수량(" + requestedQuantity + 
-                        ")이 현재 재고(" + currentStock + ")보다 많습니다.");
+            log.info("[재고 차감 호출 추적 #{}] productCode: {}, quantity: {}", 
+                    inventoryDecreaseCallCount.get(), calledProductCode, calledQuantity);
+            
+            // 동시성 제어: 원자적으로 재고 차감 시도
+            int current = currentInventory.get();
+            int newInventory = current - calledQuantity;
+            
+            log.info("[재고 차감 시도] 현재 재고: {}, 차감 수량: {}, 예상 재고: {}", 
+                    current, calledQuantity, newInventory);
+            
+            // 재고 부족 체크 및 원자적 업데이트
+            if (newInventory < 0) {
+                log.warn("[재고 차감 실패] 재고 부족 - 현재 재고: {}, 요청 수량: {}", current, calledQuantity);
+                throw new RuntimeException("재고 부족: 현재 재고 " + current + "개, 요청 수량 " + calledQuantity + "개");
             }
-        }).when(productServiceClient).decreaseInventory(productCode, orderQuantity);
-
+            
+            // 원자적으로 재고 차감
+            boolean updated = currentInventory.compareAndSet(current, newInventory);
+            if (!updated) {
+                // 다른 스레드가 이미 재고를 변경했음 - 재시도 또는 실패
+                int retryCurrent = currentInventory.get();
+                int retryNewInventory = retryCurrent - calledQuantity;
+                if (retryNewInventory < 0) {
+                    log.warn("[재고 차감 실패] 재고 부족 (재시도) - 현재 재고: {}, 요청 수량: {}", 
+                            retryCurrent, calledQuantity);
+                    throw new RuntimeException("재고 부족: 현재 재고 " + retryCurrent + "개, 요청 수량 " + calledQuantity + "개");
+                }
+                currentInventory.set(retryNewInventory);
+                log.info("[재고 차감 성공 (재시도)] 현재 재고: {} → {}", retryCurrent, retryNewInventory);
+            } else {
+                log.info("[재고 차감 성공] 현재 재고: {} → {}", current, newInventory);
+            }
+            
+            return null;
+        }).when(productServiceClient).decreaseInventory(anyString(), anyInt());
+        
         // 결제 Mock 설정 (재고 차감 성공한 주문만 결제 진행)
         doAnswer(invocation -> {
             log.info("[결제 처리] 예치금 결제 성공");
@@ -241,7 +261,7 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
 
         // 동시 시작
         log.info("========== 두 사용자 동시 주문 시작 ==========");
-        startLatch.countDown();
+        startLatch.countDown(); // 두 스레드가 동시에 시작하도록 신호
 
         // 결과 대기 (최대 10초)
         try {
@@ -256,8 +276,11 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
             // 예외는 로그로 이미 기록됨
         }
 
-        // 완료 대기
-        completionLatch.await(10, TimeUnit.SECONDS);
+        boolean completed = completionLatch.await(10, TimeUnit.SECONDS);
+        if (!completed) {
+            log.error("타임아웃 발생: 모든 주문이 10초 내에 완료되지 않았습니다.");
+            throw new AssertionError("타임아웃: 모든 주문이 10초 내에 완료되지 않았습니다.");
+        }
 
         // then: 검증
         log.info("========== 테스트 결과 검증 ==========");
@@ -268,15 +291,18 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
                 thread1Id.get() != (int) mainThreadId && thread2Id.get() != (int) mainThreadId);
         log.info("성공한 주문 수: {}", successfulOrderCount.get());
         log.info("실패한 주문 수: {}", failedOrderCount.get());
-        log.info("재고 차감 호출 횟수: {}", inventoryDecreaseCallCount.get());
+        log.info("재고 차감 호출 횟수: {}번", inventoryDecreaseCallCount.get());
 
         // 멀티 스레드 실행 검증
-        assertThat(thread1Id.get()).isNotEqualTo(thread2Id.get())
-                .as("사용자1과 사용자2는 서로 다른 스레드에서 실행되어야 합니다");
-        assertThat(thread1Id.get()).isNotEqualTo((int) mainThreadId)
-                .as("사용자1은 메인 스레드가 아닌 별도 스레드에서 실행되어야 합니다");
-        assertThat(thread2Id.get()).isNotEqualTo((int) mainThreadId)
-                .as("사용자2는 메인 스레드가 아닌 별도 스레드에서 실행되어야 합니다");
+        assertThat(thread1Id.get())
+                .as("사용자1과 사용자2는 서로 다른 스레드에서 실행되어야 합니다")
+                .isNotEqualTo(thread2Id.get());
+        assertThat(thread1Id.get())
+                .as("사용자1은 메인 스레드가 아닌 별도 스레드에서 실행되어야 합니다")
+                .isNotEqualTo((int) mainThreadId);
+        assertThat(thread2Id.get())
+                .as("사용자2는 메인 스레드가 아닌 별도 스레드에서 실행되어야 합니다")
+                .isNotEqualTo((int) mainThreadId);
 
         // 한 명만 성공하고 한 명은 실패해야 함
         assertThat(successfulOrderCount.get()).isEqualTo(1);
@@ -287,10 +313,15 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
         
         // 최종 재고 확인 (초기 3개 - 성공한 주문 2개 = 1개)
         int finalInventory = currentInventory.get();
-        log.info("최종 재고: {}개 (초기: {}개, 성공한 주문 수량: {}개)", 
-                finalInventory, testProduct.quantity(), orderQuantity);
-        assertThat(finalInventory).isEqualTo(testProduct.quantity() - orderQuantity)
-                .as("최종 재고는 초기 재고에서 성공한 주문 수량만큼 차감되어야 함");
+        log.info("========== 상품 재고량 확인 ==========");
+        log.info("원래 재고량: {}개", originalInventory);
+        log.info("동시성 테스트 후 상품 재고량: {}개", finalInventory);
+        log.info("재고 차감량: {}개 (성공한 주문 수량)", orderQuantity);
+        log.info("재고 변화: {}개 → {}개 ({}개 차감)", 
+                originalInventory, finalInventory, originalInventory - finalInventory);
+        assertThat(finalInventory)
+                .as("최종 재고는 초기 재고에서 성공한 주문 수량만큼 차감되어야 함")
+                .isEqualTo(testProduct.quantity() - orderQuantity);
 
         // 성공한 주문과 실패한 주문 확인
         List<Order> orders = orderJpaRepository.findAll();
@@ -318,14 +349,18 @@ class OrderConcurrencyTest extends BaseOrderIntegrationFailureTest {
         // 실패한 주문은 FAILED 상태이고, 재고 차감 실패 에러
         assertThat(failedOrder.getOrderStatus()).isEqualTo(OrderStatus.FAILED);
 
-        // 재고 차감 호출 확인
+        // 재고 차감 호출 확인 (2번 호출되어야 함: 두 사용자 모두 재고 차감 시도)
+        log.info("========== 재고 차감 호출 횟수 확인 ==========");
         verify(productServiceClient, times(2)).decreaseInventory(productCode, orderQuantity);
+        log.info("재고 차감 호출 횟수: {}번 (검증 완료)", inventoryDecreaseCallCount.get());
 
         // 결제는 성공한 주문에만 1번 호출
         verify(paymentServiceClient, times(1)).requestDepositPayment(any());
 
-        log.info("========== 동시성 테스트 완료 ==========");
-        log.info("결론: 비관적 락(PESSIMISTIC_WRITE)이 적용되어 동시 주문 시 재고 일관성이 유지됨");
+        log.info("========== 최종 재고량 요약 ==========");
+        log.info("원래 재고량: {}개", originalInventory);
+        log.info("동시성 테스트 후 최종 재고량: {}개", finalInventory);
+        log.info("재고 차감량: {}개", originalInventory - finalInventory);
     }
 
 }

--- a/order/src/test/resources/application-test.yml
+++ b/order/src/test/resources/application-test.yml
@@ -39,8 +39,3 @@ logging:
 current:
   domain: "http://localhost:8082"
 
-# ProductServiceClient가 Mock 서버를 호출하도록 설정
-external:
-  product-service:
-    url: http://localhost:8082  # Mock 서버 URL (테스트 환경에서 웹 서버가 시작되어야 함)
-

--- a/order/src/test/resources/application-test.yml
+++ b/order/src/test/resources/application-test.yml
@@ -31,7 +31,16 @@ logging:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
     org.hibernate.stat: DEBUG
+    # 락 쿼리 확인을 위한 로깅
+    com.ll.products: INFO  # Product 서비스 로그 (락 쿼리 실행 로그 포함)
+    com.ll.order.domain.mock: INFO  # Mock 서버 로그
+    com.ll.order.domain.client: DEBUG  # ProductServiceClient 로그
 
 current:
   domain: "http://localhost:8082"
+
+# ProductServiceClient가 Mock 서버를 호출하도록 설정
+external:
+  product-service:
+    url: http://localhost:8082  # Mock 서버 URL (테스트 환경에서 웹 서버가 시작되어야 함)
 

--- a/payment/src/main/generated/com/ll/payment/payment/model/entity/event/QPaymentRefundNotificationOutbox.java
+++ b/payment/src/main/generated/com/ll/payment/payment/model/entity/event/QPaymentRefundNotificationOutbox.java
@@ -1,0 +1,59 @@
+package com.ll.payment.payment.model.entity.event;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPaymentRefundNotificationOutbox is a Querydsl query type for PaymentRefundNotificationOutbox
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPaymentRefundNotificationOutbox extends EntityPathBase<PaymentRefundNotificationOutbox> {
+
+    private static final long serialVersionUID = 1826253309L;
+
+    public static final QPaymentRefundNotificationOutbox paymentRefundNotificationOutbox = new QPaymentRefundNotificationOutbox("paymentRefundNotificationOutbox");
+
+    public final com.ll.core.model.persistence.QBaseEntity _super = new com.ll.core.model.persistence.QBaseEntity(this);
+
+    //inherited
+    public final StringPath code = _super.code;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final StringPath lastErrorMessage = createString("lastErrorMessage");
+
+    public final StringPath notificationPayload = createString("notificationPayload");
+
+    public final DateTimePath<java.time.LocalDateTime> publishedAt = createDateTime("publishedAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Integer> retryCount = createNumber("retryCount", Integer.class);
+
+    public final EnumPath<com.ll.payment.payment.model.enums.PaymentOutboxStatus> status = createEnum("status", com.ll.payment.payment.model.enums.PaymentOutboxStatus.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QPaymentRefundNotificationOutbox(String variable) {
+        super(PaymentRefundNotificationOutbox.class, forVariable(variable));
+    }
+
+    public QPaymentRefundNotificationOutbox(Path<? extends PaymentRefundNotificationOutbox> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPaymentRefundNotificationOutbox(PathMetadata metadata) {
+        super(PaymentRefundNotificationOutbox.class, metadata);
+    }
+
+}
+

--- a/products/src/main/generated/com/ll/products/domain/product/model/entity/QProductDlqEvent.java
+++ b/products/src/main/generated/com/ll/products/domain/product/model/entity/QProductDlqEvent.java
@@ -1,0 +1,57 @@
+package com.ll.products.domain.product.model.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QProductDlqEvent is a Querydsl query type for ProductDlqEvent
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QProductDlqEvent extends EntityPathBase<ProductDlqEvent> {
+
+    private static final long serialVersionUID = 1870848442L;
+
+    public static final QProductDlqEvent productDlqEvent = new QProductDlqEvent("productDlqEvent");
+
+    public final com.ll.core.model.persistence.QBaseEntity _super = new com.ll.core.model.persistence.QBaseEntity(this);
+
+    //inherited
+    public final StringPath code = _super.code;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath eventPayload = createString("eventPayload");
+
+    public final DateTimePath<java.time.LocalDateTime> failedAt = createDateTime("failedAt", java.time.LocalDateTime.class);
+
+    //inherited
+    public final NumberPath<Long> id = _super.id;
+
+    public final EnumPath<DlqStatus> status = createEnum("status", DlqStatus.class);
+
+    public final StringPath topic = createString("topic");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+
+    public QProductDlqEvent(String variable) {
+        super(ProductDlqEvent.class, forVariable(variable));
+    }
+
+    public QProductDlqEvent(Path<? extends ProductDlqEvent> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QProductDlqEvent(PathMetadata metadata) {
+        super(ProductDlqEvent.class, metadata);
+    }
+
+}
+

--- a/products/src/main/java/com/ll/products/domain/product/service/ProductService.java
+++ b/products/src/main/java/com/ll/products/domain/product/service/ProductService.java
@@ -163,8 +163,15 @@ public class ProductService {
             }
         }
 
+        log.info("========== 락 쿼리 실행 시작 ==========");
+        log.info("상품 코드: {}, 비관적 락(PESSIMISTIC_WRITE) 적용하여 조회");
+        log.info("ProductRepository.findByCodeWithLock() 호출 -> SELECT ... FOR UPDATE 쿼리 실행");
+        
         Product product = productRepository.findByCodeWithLock(code)
                 .orElseThrow(() -> new ProductNotFoundException(code));
+        
+        log.info("========== 락 쿼리 실행 완료 ==========");
+        log.info("상품 코드: {}, 락 획득 완료, 현재 재고: {}", code, product.getQuantity());
 
         // 재고 변동 전 수량 저장
         Integer beforeQuantity = product.getQuantity();

--- a/products/src/main/java/com/ll/products/domain/product/service/ProductService.java
+++ b/products/src/main/java/com/ll/products/domain/product/service/ProductService.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class ProductService {
-    // TODO : 모든 재고 차감 성공 확인 / 차감 실패 시 결제 취소 / 재고 차감 성공 "후" 주문 완료 <- 이 부분 처리 필요
 
     private final UserClient userClient;
 
@@ -162,16 +161,8 @@ public class ProductService {
                 return;
             }
         }
-
-        log.info("========== 락 쿼리 실행 시작 ==========");
-        log.info("상품 코드: {}, 비관적 락(PESSIMISTIC_WRITE) 적용하여 조회");
-        log.info("ProductRepository.findByCodeWithLock() 호출 -> SELECT ... FOR UPDATE 쿼리 실행");
-        
         Product product = productRepository.findByCodeWithLock(code)
                 .orElseThrow(() -> new ProductNotFoundException(code));
-        
-        log.info("========== 락 쿼리 실행 완료 ==========");
-        log.info("상품 코드: {}, 락 획득 완료, 현재 재고: {}", code, product.getQuantity());
 
         // 재고 변동 전 수량 저장
         Integer beforeQuantity = product.getQuantity();

--- a/products/src/test/java/com/ll/products/domain/product/service/ProductInventoryConcurrencyTest.java
+++ b/products/src/test/java/com/ll/products/domain/product/service/ProductInventoryConcurrencyTest.java
@@ -87,7 +87,7 @@ class ProductInventoryConcurrencyTest {
                 .price(10000)
                 .status(ProductStatus.ON_SALE)
                 .isDeleted(false)
-                .images(new java.util.ArrayList<>())
+                .images(new ArrayList<>())
                 .build();
         testProduct = productRepository.save(testProduct);
     }


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 테스트 결과 로그 추가

🔗 관련 이슈
---
- 관련 이슈 번호: #216

📋 요구 사항과 구현 내용
---
- 동시 주문 테스트 로그 추가
- 불필요한 주석 삭제

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
  - 락 적용 여부를 주문 모듈의 테스트 코드에서 해야하는지
    - 결론은 상품 모듈에 작성해놓은 동시성 테스트에서 락 적용 여부를 확인할 수 있는 쿼리 로그를 확인하는 것으로 결정
    - 주문 모듈에서 검증하려면 product 서비스를 mock 서버로 실행하는 것이 아니라 실제 서버를 실행해서 검증해야하므로 시간 소요가 높음
- 트러블슈팅
- 설계 판단
- 인사이트 등














<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. 주문 동시성 통합 테스트 로직 강화 및 구조 조정 
 - `OrderConcurrencyTest` 패키지 경로를 `com.ll.order.integration`으로 변경하고 파일명을 이동해 위치를 정리 
 - `ProductMockController`를 `@Autowired`로 주입하고, `productServiceClient.getProductByCode` mock 설정을 추가해 상품 조회 흐름을 명시 
 - `productServiceClient.decreaseInventory`에 대해 `AtomicInteger` 기반의 원자적 재고 차감 로직과 재시도·부족 재고 예외 처리를 구현해 동시성 시뮬레이션을 현실적으로 개선 
 - `CountDownLatch` 대기 시 타임아웃 체크 및 실패 시 `AssertionError`를 발생시켜 테스트 안정성 강화 
 - 멀티스레드 검증의 `assertThat` 체이닝 순서를 변경해 가독성을 개선하고, 재고 로그/검증 로그를 세분화하여 디버깅 용이성 향상 

2. Mock 컨트롤러 Javadoc 제거 및 상품 Mock 컨트롤러 의존성 정리 
 - `CartMockController`, `PaymentMockController`, `ProductMockController`, `UserMockController`에서 클래스·메서드 수준 Javadoc 주석 제거 
 - `ProductMockController`에 `ProductServiceClient`, `@RequiredArgsConstructor`, `@Value` import를 추가해 향후 확장 가능성을 위한 의존성 정리 (현 diff 내에서 메서드 본문 변경은 없음) 

3. 테스트/로깅 환경 설정 보강 
 - `application-test.yml`에 `com.ll.products`, `com.ll.order.domain.mock`, `com.ll.order.domain.client` 로거를 추가하고 각각 INFO/DEBUG 레벨로 설정해 락 쿼리 및 Mock/Client 로그 추적 강화 
 - `ProductInventoryConcurrencyTest`에서 `new java.util.ArrayList<>()`를 `new ArrayList<>()`로 변경해 코드 간결화 

4. Querydsl 메타 클래스 추가 
 - 결제 도메인에 `QPaymentRefundNotificationOutbox` 생성: `status`, `notificationPayload`, `retryCount`, `publishedAt`, `lastErrorMessage` 등 필드에 대한 타입 세이프 Querydsl 경로 제공 
 - 상품 도메인에 `QProductDlqEvent` 생성: `topic`, `eventPayload`, `failedAt`, `status` 등 DLQ 이벤트 엔티티에 대한 Querydsl 경로 제공 

5. ProductService 불필요 주석 및 빈 줄 정리 
 - `ProductService` 클래스 상단의 완료된 TODO 주석 제거 및 `updateInventory` 내부의 불필요 공백 라인 삭제로 코드 정리 및 가독성 소폭 개선
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [OrderConcurrencyTest 재고 검증 로직의 자기모순 및 테스트 신뢰도 훼손 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `concurrentOrderCreation_InventoryConcurrency_OneSuccessOneFailure` 테스트에서 `originalInventory`를 `testProduct.quantity()`로 저장해두고, 최종 검증에서도 `finalInventory`를 `testProduct.quantity() - orderQuantity`로 비교하여, 재고 감소 전후 기준이 동일 객체(`testProduct`)에 종속됨.
 - 결과: 테스트 실행 중 실제 로직이 `testProduct`의 수량을 변경하거나 다른 코드가 관여하는 경우에도, 초기·최종 재고 기준이 동일 참조를 사용하여 실제 재고 일관성 붕괴를 검출하지 못할 가능성이 있음(테스트가 항상 통과하거나 잘못된 통과를 허용).
 - 위험성: 재고 동시성 제어 실패(과판매, 음수 재고 등)를 테스트가 검출하지 못해, 동시 주문 시 재고 무결성이 깨지는 버그가 실서비스에 반영될 가능성이 높아짐.

2. [OrderConcurrencyTest 재고 차감 Mock 범위 확대에 따른 오동작 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: 기존 `doAnswer().when(productServiceClient).decreaseInventory(productCode, orderQuantity);`에서 `doAnswer().when(productServiceClient).decreaseInventory(anyString(), anyInt());`로 변경되어, 테스트 중 발생하는 모든 `decreaseInventory` 호출이 동일 Mock 로직을 타도록 확장됨.
 - 결과: 해당 테스트 시나리오 외의 다른 코드 경로(다른 productCode, 수량, 혹은 재시도/보정 로직)가 동일 Mock에 의해 처리되어, 실제 도메인 로직과 다른 흐름으로 테스트가 수행될 수 있음.
 - 위험성: 동시성 제어나 재고 정책과 관련된 실제 호출 패턴이 왜곡되어, 잠재적 재고 무결성 문제나 예외 케이스가 테스트에서 가려질 수 있음.

3. [Q* Querydsl generated 클래스의 수동 커밋에 따른 빌드·런타임 불일치 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `QPaymentRefundNotificationOutbox`, `QProductDlqEvent`와 같은 Querydsl generated 파일이 VCS에 새로 추가됨.
 - 파일명: 
 - payment/src/main/generated/com/ll/payment/payment/model/entity/event/QPaymentRefundNotificationOutbox.java
 - products/src/main/generated/com/ll/products/domain/product/model/entity/QProductDlqEvent.java
 - 결과: 실제 엔티티 정의(`PaymentRefundNotificationOutbox`, `ProductDlqEvent`)가 변경되더라도 generated 소스가 재생성되지 않거나, 로컬/CI 환경에서 annotation processing 설정 차이로 클래스 정의가 불일치하는 상황이 발생할 수 있음.
 - 위험성: 엔티티-Querydsl 타입 불일치로 인한 컴파일 오류, 런타임 쿼리 실패, 예상치 못한 쿼리 동작 등의 문제가 빌드 파이프라인 혹은 운영 환경에서 발생할 가능성이 있음(특히 생성 경로가 표준 소스 디렉토리가 아니라 `generated` 디렉토리로 명시되어 있기 때문에 설정 오류 시 문제 가시성이 떨어짐).
<!-- AI-REVIEW:END -->