### PR TITLE
[feat][215] Dlq 발생시 Slack 으로 메시지 발송

### DIFF
--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -36,3 +36,6 @@ jwt:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
     implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
+    implementation "com.slack.api:slack-api-client:1.46.0"
+
     implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"

--- a/core/src/main/java/com/ll/core/config/kafka/KafkaCommonConfiguration.java
+++ b/core/src/main/java/com/ll/core/config/kafka/KafkaCommonConfiguration.java
@@ -1,5 +1,6 @@
 package com.ll.core.config.kafka;
 
+import com.ll.core.infra.slack.SlackWebhookService;
 import com.ll.core.logging.kafka.KafkaProducerLoggingListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +48,7 @@ public class KafkaCommonConfiguration {
     private Integer reconnectBackoffMaxMs;
 
     private final KafkaProperties properties;
+    private final SlackWebhookService slackWebhookService;
 
     // Producer Configuration
     @Bean
@@ -109,6 +111,7 @@ public class KafkaCommonConfiguration {
                 (record, ex) -> {
                     // Todo : DLQ 토픽 발생시 Slack Kafka DLQ Alert 구현 고려
                     log.info("DLQ Error 원인 : {}", ex.getCause().getMessage());
+                    slackWebhookService.sendMessage(record, ex);
                     return new TopicPartition(record.topic() + ".dlq", record.partition());
                 }
         );

--- a/core/src/main/java/com/ll/core/config/kafka/KafkaCommonConfiguration.java
+++ b/core/src/main/java/com/ll/core/config/kafka/KafkaCommonConfiguration.java
@@ -109,7 +109,6 @@ public class KafkaCommonConfiguration {
         return new DeadLetterPublishingRecoverer(
                 kafkaTemplate,
                 (record, ex) -> {
-                    // Todo : DLQ 토픽 발생시 Slack Kafka DLQ Alert 구현 고려
                     log.info("DLQ Error 원인 : {}", ex.getCause().getMessage());
                     slackWebhookService.sendMessage(record, ex);
                     return new TopicPartition(record.topic() + ".dlq", record.partition());
@@ -131,7 +130,6 @@ public class KafkaCommonConfiguration {
         handler.addNotRetryableExceptions(KafkaNotRetryableExceptionConfiguration.NOT_RETRYABLE_EXCEPTIONS);
 
         handler.setRetryListeners((record, ex, deliveryAttempt) ->
-                // Todo : DeliveryAttempt 값이 일정 수준 이상일 때 Slack Kafka Retry Alert 구현 고려
                 log.warn("Failed record in retry listener. topic: {}, partition: {}, offset: {}, exception: {}, message: {}, deliveryAttempt: {}",
                 record.topic(), record.partition(), record.offset(), ex.getClass().getName(), ex.getMessage(), deliveryAttempt));
 

--- a/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
+++ b/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
@@ -25,7 +25,7 @@ public class SlackWebhookService {
 
         try {
             System.out.println(message);
-//            slack.send(slackWebhookUrl, Payload.builder().text(message).build());
+            slack.send(slackWebhookUrl, Payload.builder().text(message).build());
         } catch (Exception e) {
             log.error("Failed to send Slack webhook message : {}", message, e);
         }

--- a/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
+++ b/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
@@ -24,7 +24,6 @@ public class SlackWebhookService {
         String message = getMessage(record, ex);
 
         try {
-            System.out.println(message);
             slack.send(slackWebhookUrl, Payload.builder().text(message).build());
         } catch (Exception e) {
             log.error("Failed to send Slack webhook message : {}", message, e);

--- a/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
+++ b/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
@@ -2,7 +2,6 @@ package com.ll.core.infra.slack;
 
 import com.slack.api.Slack;
 import com.slack.api.webhook.Payload;
-import com.slack.api.webhook.WebhookResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,44 +24,55 @@ public class SlackWebhookService {
         String message = getMessage(record, ex);
 
         try {
-            slack.send(slackWebhookUrl, Payload.builder().text(message).build());
+            System.out.println(message);
+//            slack.send(slackWebhookUrl, Payload.builder().text(message).build());
         } catch (Exception e) {
             log.error("Failed to send Slack webhook message : {}", message, e);
         }
     }
 
     private String getMessage(ConsumerRecord<?, ?> record, Exception ex) {
-        Throwable throwable = unwrapKafkaException(ex);
+        String exception = getUnwrapException(ex);
         return  """
+                ──────────────────────────
                 Kafka DLQ 발생 알림
-                ────────────────────────
+                ──────────────────────────
                 Topic      : %s
                 Partition  : %d
                 Offset     : %d
                 
-                Record
+                Record:
                 %s
                 
-                Exception
-                %s
-                
-                Message
+                Exception:
                 %s
                 """.formatted(
                                 record.topic(),
                                 record.partition(),
                                 record.offset(),
                                 record.value(),
-                                throwable.getClass().getSimpleName(),
-                                throwable.getMessage()
+                                exception
                         );
     }
 
-    public static Throwable unwrapKafkaException(Throwable ex) {
-        Throwable cause = ex;
-        while (cause.getCause() != null) {
-            cause = cause.getCause();
+    private String getUnwrapException(Throwable ex) {
+        StringBuilder sb = new StringBuilder();
+
+        Throwable current = ex;
+        int depth = 0;
+
+        while (current != null && depth < 5) {
+            sb.append("[")
+                    .append(current.getClass().getSimpleName())
+                    .append("]\n-> ")
+                    .append(current.getMessage())
+                    .append("\n\n");
+
+            current = current.getCause();
+            depth++;
         }
-        return cause;
+
+        return sb.toString();
     }
+
 }

--- a/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
+++ b/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
@@ -25,7 +25,7 @@ public class SlackWebhookService {
         String message = getMessage(record, ex);
 
         try {
-            WebhookResponse response = slack.send(slackWebhookUrl, Payload.builder().text(message).build());
+            slack.send(slackWebhookUrl, Payload.builder().text(message).build());
         } catch (Exception e) {
             log.error("Failed to send Slack webhook message : {}", message, e);
         }
@@ -60,8 +60,7 @@ public class SlackWebhookService {
 
     public static Throwable unwrapKafkaException(Throwable ex) {
         Throwable cause = ex;
-        while (cause instanceof org.springframework.kafka.listener.ListenerExecutionFailedException
-                || cause.getCause() != null) {
+        while (cause.getCause() != null) {
             cause = cause.getCause();
         }
         return cause;

--- a/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
+++ b/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
@@ -3,12 +3,14 @@ package com.ll.core.infra.slack;
 import com.slack.api.Slack;
 import com.slack.api.webhook.Payload;
 import com.slack.api.webhook.WebhookResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 // TODO : Slack 에 대한 내용은 차후 Notify 모듈로 분리해야 함
 @Service
+@Slf4j
 public class SlackWebhookService {
 
     @Value("${slack.webhook-url:Unknown}")
@@ -17,17 +19,15 @@ public class SlackWebhookService {
     private final Slack slack = Slack.getInstance();
 
     public void sendMessage(ConsumerRecord<?, ?> record, Exception ex) {
-        try {
-            WebhookResponse response = slack.send(slackWebhookUrl, Payload.builder().text(getMessage(record, ex)).build());
+        if ( "Unknown".equals(slackWebhookUrl) ) {
+            return;
+        }
+        String message = getMessage(record, ex);
 
-            if (response.getCode() != 200 || !"ok".equals(response.getBody())) {
-                throw new IllegalStateException(
-                        "Slack webhook failed. code=" + response.getCode()
-                                + ", body=" + response.getBody()
-                );
-            }
+        try {
+            WebhookResponse response = slack.send(slackWebhookUrl, Payload.builder().text(message).build());
         } catch (Exception e) {
-            throw new RuntimeException("Failed to send Slack message", e);
+            log.error("Failed to send Slack webhook message : {}", message, e);
         }
     }
 

--- a/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
+++ b/core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java
@@ -1,0 +1,69 @@
+package com.ll.core.infra.slack;
+
+import com.slack.api.Slack;
+import com.slack.api.webhook.Payload;
+import com.slack.api.webhook.WebhookResponse;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+// TODO : Slack 에 대한 내용은 차후 Notify 모듈로 분리해야 함
+@Service
+public class SlackWebhookService {
+
+    @Value("${slack.webhook-url:Unknown}")
+    private String slackWebhookUrl;
+
+    private final Slack slack = Slack.getInstance();
+
+    public void sendMessage(ConsumerRecord<?, ?> record, Exception ex) {
+        try {
+            WebhookResponse response = slack.send(slackWebhookUrl, Payload.builder().text(getMessage(record, ex)).build());
+
+            if (response.getCode() != 200 || !"ok".equals(response.getBody())) {
+                throw new IllegalStateException(
+                        "Slack webhook failed. code=" + response.getCode()
+                                + ", body=" + response.getBody()
+                );
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to send Slack message", e);
+        }
+    }
+
+    private String getMessage(ConsumerRecord<?, ?> record, Exception ex) {
+        Throwable throwable = unwrapKafkaException(ex);
+        return  """
+                Kafka DLQ 발생 알림
+                ────────────────────────
+                Topic      : %s
+                Partition  : %d
+                Offset     : %d
+                
+                Record
+                %s
+                
+                Exception
+                %s
+                
+                Message
+                %s
+                """.formatted(
+                                record.topic(),
+                                record.partition(),
+                                record.offset(),
+                                record.value(),
+                                throwable.getClass().getSimpleName(),
+                                throwable.getMessage()
+                        );
+    }
+
+    public static Throwable unwrapKafkaException(Throwable ex) {
+        Throwable cause = ex;
+        while (cause instanceof org.springframework.kafka.listener.ListenerExecutionFailedException
+                || cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+}

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -33,3 +33,6 @@ management:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -35,3 +35,6 @@ custom:
       size: 100
     skip:
       limit: 10
+
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL}

--- a/products/src/main/resources/application.yml
+++ b/products/src/main/resources/application.yml
@@ -34,3 +34,6 @@ management:
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+slack:
+    webhook-url: ${SLACK_WEBHOOK_URL}


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Dlq 발생시 Slack 으로 메시지 발송

🔗 관련 이슈
---
- 관련 이슈 번호: #215

📋 요구 사항과 구현 내용
---
- Dlq 발생시 Slack 으로 메시지 발송
- 원래 core 에는 Service 로직을 넣으면 안되지만, 시간관계상 새로운 모듈을 추가하는건 큰 부담이 되기 때문에 core 에 넣었습니다

💬 TODO 리스트
---
- [ ] 차후 notify 모듈로 분리
- [ ] 사실 이 내용은 `Kafka 수동 조작을 해서라도 정합성을 맞추겠습니다` 라고 보여주기식으로 만든 코드라 필요성에 대해서는 검토를 해봐야 할 듯 합니다.

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등














<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Kafka DLQ Slack 알림 기능 추가 
 - `SlackWebhookService` 신규 구현: `slack.webhook-url` 설정값을 사용해 Slack Webhook 전송 
 - Kafka DLQ 처리용 `DeadLetterPublishingRecoverer`에서 DLQ 발생 시 `slackWebhookService.sendMessage(record, ex)` 호출하여 알림 발송 
 - 예외 체인을 최대 5단계까지 풀어서 메시지에 포함하고, Topic/Partition/Offset/Record 정보까지 상세히 전송 
 - Slack 전송 실패 시 에러 로그만 남기고 애플리케이션 로직에는 영향 주지 않도록 예외 처리

2. Slack 연동 인프라 및 의존성 설정 
 - `core/build.gradle`에 `com.slack.api:slack-api-client:1.46.0` 의존성 추가 
 - `KafkaCommonConfiguration`에 `SlackWebhookService` 주입 필드 추가 및 관련 import 추가 
 - `auth`, `order`, `payment`, `products` 모듈 `application.yml`에 `slack.webhook-url: ${SLACK_WEBHOOK_URL}` 설정 추가하여 공통 환경변수 기반으로 Webhook URL 관리
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [Slack Webhook URL 미설정 시 DLQ 알림 누락]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `SlackWebhookService`에서 `slack.webhook-url` 값이 없으면 기본값 `"Unknown"`으로 두고, 이 값일 경우 `sendMessage` 전체 로직을 바로 return하도록 구현됨.
 - 결과: 운영 환경에서 `SLACK_WEBHOOK_URL` 환경변수(또는 `slack.webhook-url` 설정) 누락 시, Kafka DLQ 발생 알림이 전혀 전달되지 않음.
 - 위험성: Kafka DLQ 누적 및 장애 상황을 실시간으로 인지하지 못해 장애 탐지·대응이 지연될 수 있음 (서비스 중단 징후를 조기에 파악하지 못할 가능성).

 - 해당 코드:
 - `core/src/main/java/com/ll/core/infra/slack/SlackWebhookService.java`:
 ```java
 @Value("${slack.webhook-url:Unknown}")
 private String slackWebhookUrl;

 public void sendMessage(ConsumerRecord<?, ?> record, Exception ex) {
 if ( "Unknown".equals(slackWebhookUrl) ) {
 return;
 }
 ...
 }
 ```
<!-- AI-REVIEW:END -->