### PR TITLE
[fix][221] BaseEntity 및 SwaggerConfig 일부 변경

### DIFF
--- a/core/src/main/java/com/ll/core/config/swagger/SwaggerConfig.java
+++ b/core/src/main/java/com/ll/core/config/swagger/SwaggerConfig.java
@@ -53,7 +53,7 @@ public class SwaggerConfig {
 
             if (target != null) {
                 target.in(ParameterIn.HEADER.toString());
-                target.setRequired(true);
+                target.setRequired(false);
                 target.setName("X-User-Code");
                 target.setDescription("사용자 고유 코드");
                 target.schema(new StringSchema().type("string").example("X-User-Code ex) 019a90ab-fcf3-7413-af08-7121cc99378b"));

--- a/core/src/main/java/com/ll/core/model/persistence/BaseEntity.java
+++ b/core/src/main/java/com/ll/core/model/persistence/BaseEntity.java
@@ -35,12 +35,12 @@ public abstract class BaseEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         BaseEntity that = (BaseEntity) o;
-        return Objects.equals(id, that.id) && Objects.equals(code, that.code);
+        return Objects.equals(code, that.code);
     }
 
     @Override
     public int hashCode() {
-        return getClass().hashCode();
+        return Objects.hash(code);
     }
 
 }


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
-  BaseEntity 의 equals 과 hashCode 를 code 기반으로 변경

🔗 관련 이슈
---
- 관련 이슈 번호: #221

📋 요구 사항과 구현 내용
---
- Swagger 의 X-User-Code 필수 -> 선택 변환
- BaseEntity 의 equals 과 hashCode 를 code 기반으로 변경

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
  - 문제 원인 분석
    - BaseEntity의 id는 GenerationType.IDENTITY 전략을 사용하고 있음
      - 해당 전략은 DB에 영속화되는 시점에 id 값이 생성 됨
      - 즉, 엔티티 인스턴스 생성 시점에는 id가 null이며, 생명주기 중 값이 변경되는 불변성이 보장되지 않는 필드
      - 이로 인해 id를 기준으로 equals를 판단할 경우, 영속화 전/후 엔티티의 동일성 기준이 달라질 수 있어 객체 동일성 판단에 혼란을 야기할 수 있음.
    - 또한 hashCode가 getClass() 기반으로 구현되어 있어,  동일한 엔티티 타입의 모든 인스턴스가 같은 hashCode 값을 갖게 됨.
      - Hash 기반 컬렉션(HashSet, HashMap)을 사용할 경우,  모든 엔티티 인스턴스가 하나의 버킷에 몰릴 수 있음.
      - 이 경우 평균 시간 복잡도 O(1)이 아닌 O(n)으로 성능이 급격히 저하될 위험이 존재함.
  
  - 해결 방안
    - 엔티티 생성 시점에 UUID 기반으로 값이 고정되며,  이후 변경되지 않는 code 필드를 동일성 기준으로 사용하도록 결정.
    - equals와 hashCode 모두 code를 기준으로 구현하여, 엔티티 생명주기 동안 동일성 판단 기준이 변하지 않도록 보장.
    - Hash 기반 컬렉션 사용 시에도 hash 분산이 정상적으로 이루어지도록 개선.
    ```Java
    @Override
    public boolean equals(Object o) {
        if (this == o) return true;
        if (o == null || getClass() != o.getClass()) return false;
        BaseEntity that = (BaseEntity) o;
        return Objects.equals(code, that.code);
    }
    
    @Override
    public int hashCode() {
        return Objects.hash(code);
    }
    ```
  - 결과
    - 엔티티 동일성 판단 기준이 불변 값(code)으로 명확해짐.
    - id 생성 시점에 따른 equals 판단 불일치 가능성 제거.
    - Hash 기반 컬렉션 사용 시 성능 저하 및 잠재적 버그 위험 해소.

- 설계 판단
- 인사이트 등

<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. SwaggerConfig에서 X-User-Code 헤더 필수 여부 완화 
 - `hideUserCodeHeader()` 내 `X-User-Code` 헤더 파라미터의 `setRequired(true)`를 `setRequired(false)`로 변경 
 - Swagger 문서 상에서 해당 헤더가 선택적(optional)으로 표시되도록 수정 

2. BaseEntity 동등성 비교 및 해시 전략 변경 
 - `equals`에서 `id`와 `code` 동시 비교 로직을 제거하고, `code`만으로 동등성 판단하도록 수정 
 - `hashCode` 구현을 `getClass().hashCode()`에서 `Objects.hash(code)`로 변경하여 `code` 기반 해시 생성 
 - 동일 `code`를 가진 엔티티들을 동등하게 취급하고 컬렉션 동작 시 일관성을 강화하도록 의도된 변경으로 보임
<!-- AI-GENERATOR:END -->