### PR TITLE
[refactor][227] 주문 취소 상태값 추가

### DIFF
--- a/order/src/main/java/com/ll/order/domain/model/enums/order/OrderStatus.java
+++ b/order/src/main/java/com/ll/order/domain/model/enums/order/OrderStatus.java
@@ -14,7 +14,7 @@ public enum OrderStatus {
             case CREATED -> target == PAID || target == CANCELLED || target == FAILED;
             case PAID -> target == DELIVERY || target == CANCELLED || target == REFUNDED;
             case DELIVERY -> target == COMPLETED || target == REFUNDED;
-            case COMPLETED -> target == REFUNDED;
+            case COMPLETED -> target == REFUNDED || target == CANCELLED;
             case CANCELLED, REFUNDED -> false;
             case FAILED -> false;
         };

--- a/order/src/test/resources/application-test.yml
+++ b/order/src/test/resources/application-test.yml
@@ -39,3 +39,7 @@ logging:
 current:
   domain: "http://localhost:8082"
 
+# Slack 설정 (테스트 환경에서는 Unknown 값 사용 - SlackWebhookService에서 Unknown일 경우 메시지 전송하지 않음)
+slack:
+  webhook-url: Unknown
+


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 주문 취소 상태값 추가

🔗 관련 이슈
---
- 관련 이슈 번호: #227

📋 요구 사항과 구현 내용
---
- 테스트 실행에 필요한 yml 설정 추가
- 주문 취소 시 request로 CANCELLED 상태값 가능하도록추가 

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. OrderStatus 상태 전이 규칙 변경 
 - `OrderStatus.COMPLETED` 상태에서 `CANCELLED` 로의 전이가 허용되도록 `canTransitionTo` 로직 수정 
 - 기존에는 `COMPLETED` → `REFUNDED` 만 가능했으나, 이제 `COMPLETED` → `REFUNDED` 또는 `CANCELLED` 둘 다 가능 

2. 테스트 환경 Slack 설정 추가 
 - `application-test.yml`에 `slack.webhook-url: Unknown` 설정 추가 
 - 주석으로 테스트 환경에서는 Unknown 값 사용 시 `SlackWebhookService`에서 실제 Slack 메시지를 전송하지 않음을 명시 
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [COMPLETED 상태에서 CANCELLED 로의 역행 상태 전이 허용]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `OrderStatus.canTransitionTo`에서 `COMPLETED` 상태가 `CANCELLED` 로도 전이 가능하도록 조건을 추가함.
 - 결과: 한 번 완료된 주문이 이후에 취소 상태로 바뀔 수 있어, 주문 라이프사이클이 비가역적이라는 전제(정산, 세금, 배송 처리 등)와 충돌할 수 있음.
 - 위험성: 결제/정산/재고/배송 등 다른 도메인에서 `COMPLETED` 를 최종 확정 상태로 간주하는 경우, 데이터 무결성 및 회계/정산 로직이 어긋나 서비스 및 비즈니스 로직에 중대한 오류를 유발할 수 있음.

2. [테스트 환경에서 Slack 미발송 설정으로 인한 알림 누락]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `application-test.yml`에서 `slack.webhook-url`을 `Unknown`으로 설정하고, `SlackWebhookService`가 이 값일 경우 메시지를 전송하지 않도록 명시함.
 - 결과: 테스트 환경에서 Slack 연동을 이용한 장애/에러 알림, 중요 비즈니스 이벤트 알림이 발생하지 않음.
 - 위험성: 테스트·QA 단계에서 Slack 알림을 통한 문제 조기 발견이 차단되어, 프로덕션 배포 시까지 치명적 버그나 설정 오류가 노출되지 않을 가능성이 있음.

잠정적 문제 가능성

1. [주문 상태 전이 규칙 변경에 대한 도메인/정책 불일치 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: diff 상에서 다른 도메인 서비스(결제, 배송, 정산 등)의 상태 처리 로직 변경이 보이지 않는 상태에서, `COMPLETED -> CANCELLED` 전이만 단독으로 허용됨.
 - 결과: 외부 또는 다른 모듈이 여전히 `COMPLETED` 를 최종 종결 상태로 가정하고 있을 경우, 상태 불일치나 이중 처리(중복 환불, 재고 롤백 누락 등)가 발생할 수 있음.
 - 위험성: 전체 코드 문맥이 없어 정확한 영향 범위는 판단 불가이나, 상태 머신 규칙 변경이 타 모듈과 합의 없이 이뤄졌다면 서비스 전반에 걸친 논리 오류를 유발할 수 있음.
<!-- AI-REVIEW:END -->