### PR TITLE
[refactor][227] 아웃박스 참조 코드 수정

### DIFF
--- a/order/src/main/java/com/ll/order/domain/messaging/producer/OrderEventProducer.java
+++ b/order/src/main/java/com/ll/order/domain/messaging/producer/OrderEventProducer.java
@@ -1,6 +1,5 @@
 package com.ll.order.domain.messaging.producer;
 
-import com.fasterxml.uuid.Generators;
 import com.ll.core.config.kafka.KafkaEventPublisher;
 import com.ll.core.model.vo.kafka.InventoryEvent;
 import com.ll.core.model.vo.kafka.OrderEvent;
@@ -35,8 +34,7 @@ public class OrderEventProducer {
         kafkaEventPublisher.publish("payment-refund-request-event", event);
     }
 
-    public void sendInventoryRollback(String productCode, int quantity) {
-        String referenceCode = Generators.timeBasedEpochGenerator().generate().toString();
+    public void sendInventoryRollback(String productCode, int quantity, String referenceCode) {
         kafkaEventPublisher.publish("inventory-event", InventoryEvent.stockRollbackEvent(productCode, quantity, referenceCode));
     }
 }

--- a/order/src/main/java/com/ll/order/domain/service/event/InventoryRollbackEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/InventoryRollbackEventOutboxService.java
@@ -105,7 +105,8 @@ public class InventoryRollbackEventOutboxService {
 
             orderEventProducer.sendInventoryRollback(
                     inventoryEvent.productCode(),
-                    inventoryEvent.quantity()
+                    inventoryEvent.quantity(),
+                    inventoryEvent.referenceCode()
             );
 
             log.debug("재고 롤백 이벤트 발행 성공 - outboxId: {}, referenceCode: {}, retryCount: {}",


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 핵심 변경 사항 요약

🔗 관련 이슈
---
- 관련 이슈 번호: #227

📋 요구 사항과 구현 내용
---
- 아웃박스 데이터의 참조 코드 저장 순서 변경

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Inventory rollback 이벤트 참조 코드 처리 방식 변경 
 - `OrderEventProducer.sendInventoryRollback` 시그니처를 `(String productCode, int quantity, String referenceCode)`로 변경하여, 외부에서 참조 코드를 주입받도록 수정 
 - 메서드 내부에서 사용하던 `Generators.timeBasedEpochGenerator().generate()` 기반 referenceCode 생성 로직 제거 및 `com.fasterxml.uuid.Generators` import 삭제 

2. InventoryRollbackEventOutbox 연동 개선 
 - `InventoryRollbackEventOutboxService.publishEvent`에서 `orderEventProducer.sendInventoryRollback` 호출 시 `inventoryEvent.referenceCode()`를 함께 전달하도록 수정 
 - Outbox에 저장된 referenceCode를 그대로 사용해 재고 롤백 이벤트의 트레이싱/일관성을 유지하도록 호출 구조 정리
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [InventoryRollback 이벤트 식별자 생성 방식 변경으로 인한 참조 코드 누락/불일치 위험]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `OrderEventProducer.sendInventoryRollback`가 내부에서 `referenceCode`를 생성하던 방식에서, 외부에서 전달받은 `referenceCode`만 사용하도록 변경됨.
 - 파일명: `order/src/main/java/com/ll/order/domain/messaging/producer/OrderEventProducer.java`
 - 코드블록:
 ```java
 - public void sendInventoryRollback(String productCode, int quantity) {
 - String referenceCode = Generators.timeBasedEpochGenerator().generate().toString();
 + public void sendInventoryRollback(String productCode, int quantity, String referenceCode) {
 kafkaEventPublisher.publish("inventory-event", InventoryEvent.stockRollbackEvent(productCode, quantity, referenceCode));
 }
 ```
 - 결과: `sendInventoryRollback` 호출부가 모두 이 변경된 시그니처에 맞게 수정되지 않았거나, `inventoryEvent.referenceCode()`가 null/비정상 값일 경우, InventoryEvent에 잘못된 referenceCode가 기록될 수 있음.
 - 파일명: `order/src/main/java/com/ll/order/domain/service/event/InventoryRollbackEventOutboxService.java`
 - 코드블록:
 ```java
 - orderEventProducer.sendInventoryRollback(
 - inventoryEvent.productCode(),
 - inventoryEvent.quantity()
 - );
 + orderEventProducer.sendInventoryRollback(
 + inventoryEvent.productCode(),
 + inventoryEvent.quantity(),
 + inventoryEvent.referenceCode()
 + );
 ```
 - 위험성: referenceCode가 주문·결제·재고 롤백의 추적 키로 사용되는 구조라면, 잘못된/누락된 referenceCode로 인해 재고 롤백 이벤트와 원 거래를 정확히 매칭하지 못하여 재고 수량 불일치(데이터 무결성 훼손) 또는 중복/누락 롤백이 발생할 수 있음.

2. [잠정적 문제 가능성: sendInventoryRollback 호출부 누락/컴파일 오류 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `OrderEventProducer.sendInventoryRollback`의 메서드 시그니처가 변경되었으나, diff에는 `InventoryRollbackEventOutboxService` 외의 다른 호출부 수정 여부가 나타나지 않음.
 - 파일명: `order/src/main/java/com/ll/order/domain/messaging/producer/OrderEventProducer.java`
 - 코드블록:
 ```java
 - public void sendInventoryRollback(String productCode, int quantity) {
 + public void sendInventoryRollback(String productCode, int quantity, String referenceCode) {
 ```
 - 결과: 다른 클래스에서 여전히 옛 시그니처(`(String, int)`)로 호출하고 있다면 컴파일 에러가 발생하여 빌드/배포가 불가능해짐.
 - 위험성: 실제로 다른 호출부가 존재하는지 diff만으로 확인할 수 없어, 현재 상태에서는 판단 불가이나, 존재할 경우 서비스 배포 불가(서비스 중단)로 직결될 수 있음.
<!-- AI-REVIEW:END -->