### PR TITLE
[Docs][220] 상품 모듈 swagger 작성

### DIFF
--- a/products/src/main/java/com/ll/products/domain/cart/controller/CartController.java
+++ b/products/src/main/java/com/ll/products/domain/cart/controller/CartController.java
@@ -6,11 +6,14 @@ import com.ll.products.domain.cart.model.vo.response.CartItemAddResponse;
 import com.ll.products.domain.cart.model.vo.response.CartItemRemoveResponse;
 import com.ll.products.domain.cart.model.vo.response.CartItemsResponse;
 import com.ll.products.domain.cart.service.CartService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Cart", description = "장바구니 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/carts")
@@ -18,6 +21,7 @@ public class CartController {
 
     private final CartService cartService;
 
+    @Operation(summary = "장바구니 상품 추가")
     @PostMapping("/cartItems")
     public ResponseEntity<BaseResponse<CartItemAddResponse>> addCartItem(
             @RequestHeader("X-User-Code") String userCode,
@@ -28,6 +32,7 @@ public class CartController {
         return BaseResponse.ok(response);
     }
 
+    @Operation(summary = "장바구니 상품 삭제")
     @DeleteMapping("/cartItems/{cartItemCode}")
     public ResponseEntity<BaseResponse<CartItemRemoveResponse>> removeCartItem(
             @PathVariable String cartItemCode,
@@ -38,6 +43,7 @@ public class CartController {
         return BaseResponse.ok(response);
     }
 
+    @Operation(summary = "장바구니 상품 조회")
     @GetMapping("/cartItems")
     public ResponseEntity<BaseResponse<CartItemsResponse>> getCartItems(
             @RequestHeader("X-User-Code") String userCode

--- a/products/src/main/java/com/ll/products/domain/category/controller/CategoryController.java
+++ b/products/src/main/java/com/ll/products/domain/category/controller/CategoryController.java
@@ -1,6 +1,8 @@
 package com.ll.products.domain.category.controller;
 
 import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +14,7 @@ import com.ll.products.domain.category.service.CategoryService;
 
 import java.util.List;
 
+@Tag(name = "Category", description = "상품 카테고리 관리 API")
 @RestController
 @RequestMapping("/api/categories")
 @RequiredArgsConstructor
@@ -19,44 +22,42 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-
-
-    // 카테고리 생성
+    @Operation(summary = "카테고리 생성")
     @PostMapping
     public ResponseEntity<BaseResponse<CategoryResponse>> createCategory(@Valid @RequestBody CategoryCreateRequest request) {
         CategoryResponse response = categoryService.createCategory(request);
         return BaseResponse.created(response);
     }
 
-    // 카테고리 상세 조회
+    @Operation(summary = "카테고리 상세 조회")
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<CategoryResponse>> getCategory(@PathVariable Long id) {
         CategoryResponse response = categoryService.getCategory(id);
         return BaseResponse.ok(response);
     }
 
-    // 최상위 카테고리 목록 조회
+    @Operation(summary = "최상위 카테고리 목록 조회")
     @GetMapping("/root")
     public ResponseEntity<BaseResponse<List<CategoryResponse>>> getRootCategories() {
         List<CategoryResponse> response = categoryService.getRootCategories();
         return BaseResponse.ok(response);
     }
 
-    // 카테고리 전체 조회 (flat)
+    @Operation(summary = "카테고리 전체 조회(flat)")
     @GetMapping
     public ResponseEntity<BaseResponse<List<CategoryResponse>>> getAllCategoriesFlat() {
         List<CategoryResponse> response = categoryService.getAllCategoriesFlat();
         return BaseResponse.ok(response);
     }
 
-    // 카테고리 전체 조회(tree)
+    @Operation(summary = "카테고리 전체 조회(tree)")
     @GetMapping("/tree")
     public ResponseEntity<BaseResponse<List<CategoryResponse>>> getAllCategoriesTree() {
         List<CategoryResponse> response = categoryService.getAllCategoriesTree();
         return BaseResponse.ok(response);
     }
 
-    // 카테고리 수정
+    @Operation(summary = "카테고리 수정")
     @PutMapping("/{id}")
     public ResponseEntity<BaseResponse<CategoryResponse>> updateCategory(
             @PathVariable Long id,
@@ -65,7 +66,7 @@ public class CategoryController {
         return BaseResponse.ok(response);
     }
 
-    // 카테고리 삭제
+    @Operation(summary = "카테고리 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> deleteCategory(@PathVariable Long id) {
         categoryService.deleteCategory(id);

--- a/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
@@ -2,7 +2,10 @@ package com.ll.products.domain.product.controller;
 
 import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.history.service.HistoryFacadeService;
+import com.ll.products.domain.product.controller.swagger.*;
 import com.ll.products.domain.product.model.dto.request.ProductUpdateInventoryRequest;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +25,7 @@ import com.ll.products.domain.product.service.ProductService;
 
 import java.util.List;
 
+@Tag(name = "Product", description = "상품 관리 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/products")
@@ -36,6 +40,7 @@ public class ProductController {
 
     // 1. 상품 생성
     @PostMapping
+    @ProductCreateApiResponse
     public ResponseEntity<BaseResponse<ProductResponse>> createProduct(
             @Valid @RequestBody ProductCreateRequest request,
             @RequestHeader("X-User-Code") String sellerCode,
@@ -47,9 +52,10 @@ public class ProductController {
 
     // 2. 상품 상세조회
     @GetMapping("/{code}")
+    @ProductGetApiResponse
     public ResponseEntity<BaseResponse<ProductResponse>> getProduct(
             @PathVariable String code,
-            @RequestHeader(value = "X-User-Code",required = false) String userCode) {
+            @RequestHeader(value = "X-User-Code", required = false) String userCode) {
 
         ProductResponse response = productService.getProduct(code);
         if(userCode != null){
@@ -61,6 +67,7 @@ public class ProductController {
 
     // 3. 상품 목록조회
     @GetMapping
+    @ProductListApiResponse
     public ResponseEntity<BaseResponse<Page<ProductListResponse>>> getProducts(
             @RequestParam(required = false) String sellerCode,
             @RequestParam(required = false) Long categoryId,
@@ -76,6 +83,7 @@ public class ProductController {
 
     // 4. 상품 삭제(soft delete)
     @DeleteMapping("/{code}")
+    @ProductDeleteApiResponse
     public ResponseEntity<BaseResponse<Void>> deleteProduct(
             @PathVariable String code,
             @RequestHeader("X-User-Code") String userCode,
@@ -87,6 +95,7 @@ public class ProductController {
 
     // 5. 상품 수정
     @PutMapping("/{code}")
+    @ProductUpdateApiResponse
     public ResponseEntity<BaseResponse<ProductResponse>> updateProduct(
             @PathVariable String code,
             @Valid @RequestBody ProductUpdateRequest request,
@@ -99,6 +108,7 @@ public class ProductController {
 
     // 6. 상품 상태변경
     @PatchMapping("/{code}/status")
+    @ProductUpdateStatusApiResponse
     public ResponseEntity<BaseResponse<ProductResponse>> updateProductStatus(
             @PathVariable String code,
             @Valid @RequestBody ProductUpdateStatusRequest request,
@@ -111,6 +121,7 @@ public class ProductController {
 
     // 7. 재고 변동 ( 증가/감소 )
     @PatchMapping("/{code}/inventory")
+    @ProductUpdateInventoryApiResponse
     public ResponseEntity<BaseResponse<Void>> updateInventory(
             @PathVariable String code,
             @Valid @RequestBody ProductUpdateInventoryRequest request

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductCreateApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductCreateApiResponse.java
@@ -1,0 +1,162 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.product.model.dto.request.ProductCreateRequest;
+import com.ll.products.domain.product.model.dto.response.ProductResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 생성",
+        description = """
+                새로운 상품을 등록합니다.
+                
+                - 판매자 권한이 필요합니다.
+                - 상품명, 설명, 가격, 재고 등의 정보를 입력받습니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "판매자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        ),
+        @Parameter(
+                name = "X-Role",
+                in = ParameterIn.HEADER,
+                description = "사용자 권한",
+                required = true,
+                example = "SELLER"
+        )
+})
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ProductCreateRequest.class),
+                examples = {
+                        @ExampleObject(
+                                name = "상품 생성 요청",
+                                value = """
+                                        {
+                                        "name": "해리포터 안경",
+                                        "categoryId": 21,
+                                        "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품,",
+                                        "price": 22000,
+                                        "quantity": 3,
+                                        "images": [
+                                        {
+                                        "fileKey": "fileKeyExample",
+                                        "sequence": 0,
+                                        "isMain" : true
+                                        }
+                                        ]
+                                        }
+                                        """
+                        )
+                }
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "201",
+                description = "상품 생성 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ProductResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "201 - 상품 생성 성공",
+                                        description = "상품이 정상적으로 생성된 경우",
+                                        value = """
+                                                  {
+                                                  "status": 201,
+                                                  "message": "success",
+                                                  "data": {
+                                                    "id": 1,
+                                                    "code": "019b24ab-8593-7cfe-bf2d-535bd8a327fa",
+                                                    "name": "해리포터 안경",
+                                                    "categoryId": 21,
+                                                    "categoryName": "해리포터",
+                                                    "sellerCode": "019a90ab-fcf3-7413-af08-7121cc99378b",
+                                                    "sellerName": "판매자01",
+                                                    "status": "WAITING",
+                                                    "quantity": 3,
+                                                    "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품,",
+                                                    "price": 22000,
+                                                    "images": [
+                                                      {
+                                                        "url": "https://team-404-bucket.s3.ap-northeast-2.amazonaws.com/fileKeyExample",
+                                                        "sequence": 0,
+                                                        "isMain": true
+                                                      }
+                                                    ],
+                                                    "createdAt": "2025-12-16T09:59:39.286104",
+                                                    "updatedAt": "2025-12-16T09:59:39.286104"
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - 필수 필드 누락",
+                                        description = "필수 입력값이 누락된 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "상품명은 필수입니다",
+                                                  "errorCode": "BAD_REQUEST"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "403 - 권한 없음",
+                                        description = "판매자 권한이 없는 경우",
+                                        value = """
+                                                {
+                                                  "status": 403,
+                                                  "message": "상품에 대한 권한이 없습니다. 상품코드: 상품 생성 권한 없음",
+                                                  "errorCode": "FORBIDDEN"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductCreateApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductCreateApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductCreateApiResponse.java
@@ -78,7 +78,7 @@ import java.lang.annotation.*;
                 description = "상품 생성 성공",
                 content = @Content(
                         mediaType = "application/json",
-                        schema = @Schema(implementation = ProductResponse.class),
+                        schema = @Schema(implementation = BaseResponse.class),
                         examples = {
                                 @ExampleObject(
                                         name = "201 - 상품 생성 성공",

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductDeleteApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductDeleteApiResponse.java
@@ -1,0 +1,116 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 삭제",
+        description = """
+                상품을 삭제합니다 (Soft Delete).
+
+                - 판매자는 본인의 상품만 삭제 가능합니다.
+                - 관리자는 모든 상품을 삭제할 수 있습니다.
+                - 실제로 데이터가 삭제되지 않고 상태가 DELETED로 변경됩니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "code",
+                in = ParameterIn.PATH,
+                description = "상품 코드",
+                required = true
+        ),
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        ),
+        @Parameter(
+                name = "X-Role",
+                in = ParameterIn.HEADER,
+                description = "사용자 권한",
+                required = true,
+                example = "SELLER"
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "상품 삭제 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 상품 삭제 성공",
+                                        description = "상품이 정상적으로 삭제된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": null
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "403 - 권한 없음",
+                                        description = "본인의 상품이 아니거나 권한이 없는 경우",
+                                        value = """
+                                                {
+                                                  "status": 403,
+                                                  "message": "상품 삭제 권한이 없습니다.",
+                                                  "errorCode": "FORBIDDEN"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "상품을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 상품 없음",
+                                        description = "해당 코드의 상품이 존재하지 않는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "상품을 찾을 수 없습니다.",
+                                                  "errorCode": "PRODUCT_NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductDeleteApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductGetApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductGetApiResponse.java
@@ -1,0 +1,109 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.product.model.dto.response.ProductResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 상세 조회",
+        description = """
+                상품 코드를 통해 상품의 상세 정보를 조회합니다.
+                
+                - 로그인한 사용자의 경우 조회 이력이 저장됩니다.
+                - 비로그인 사용자도 조회 가능합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "code",
+                in = ParameterIn.PATH,
+                description = "상품 코드",
+                required = true
+        ),
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드 (선택)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "상품 조회 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ProductResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 상품 조회 성공",
+                                        description = "상품 정보가 정상적으로 조회된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": {
+                                                    "id": 1,
+                                                    "code": "019b24ab-8593-7cfe-bf2d-535bd8a327fa",
+                                                    "name": "해리포터 안경",
+                                                    "categoryId": 21,
+                                                    "categoryName": "해리포터",
+                                                    "sellerCode": "019a90ab-fcf3-7413-af08-7121cc99378b",
+                                                    "sellerName": "알 수 없는 판매자",
+                                                    "status": "WAITING",
+                                                    "quantity": 3,
+                                                    "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품,",
+                                                    "price": 22000,
+                                                    "images": [
+                                                      {
+                                                        "url": "https://team-404-bucket.s3.ap-northeast-2.amazonaws.com/fileKeyExample",
+                                                        "sequence": 0,
+                                                        "isMain": true
+                                                      }
+                                                    ],
+                                                    "createdAt": "2025-12-16T09:59:39.286104",
+                                                    "updatedAt": "2025-12-16T09:59:39.286104"
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "상품을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 상품 없음",
+                                        description = "해당 코드의 상품이 존재하지 않는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "상품을 찾을 수 없습니다. 상품코드: 019b24ab-8593-7cfe-bf2d-535bd8a327fa1",
+                                                  "errorCode": "NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductGetApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductGetApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductGetApiResponse.java
@@ -46,7 +46,7 @@ import java.lang.annotation.*;
                 description = "상품 조회 성공",
                 content = @Content(
                         mediaType = "application/json",
-                        schema = @Schema(implementation = ProductResponse.class),
+                        schema = @Schema(implementation = BaseResponse.class),
                         examples = {
                                 @ExampleObject(
                                         name = "200 - 상품 조회 성공",

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductListApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductListApiResponse.java
@@ -82,7 +82,6 @@ import java.lang.annotation.*;
                                                         "code": "PRD001",
                                                         "name": "상품명",
                                                         "price": 10000,
-                                                        "inventory": 100,
                                                         "status": "ACTIVE"
                                                       }
                                                     ],

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductListApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductListApiResponse.java
@@ -1,0 +1,102 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 목록 조회",
+        description = """
+                상품 목록을 페이지네이션으로 조회합니다.
+
+                - 다양한 필터링 옵션을 제공합니다 (판매자, 카테고리, 상태, 상품명).
+                - 정렬 기준은 기본적으로 생성일자 내림차순입니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "sellerCode",
+                in = ParameterIn.QUERY,
+                description = "판매자 코드로 필터링 (선택)",
+                required = false
+        ),
+        @Parameter(
+                name = "categoryId",
+                in = ParameterIn.QUERY,
+                description = "카테고리 ID로 필터링 (선택)",
+                required = false
+        ),
+        @Parameter(
+                name = "status",
+                in = ParameterIn.QUERY,
+                description = "상품 상태로 필터링 (ACTIVE, INACTIVE, DELETED) (선택)",
+                required = false
+        ),
+        @Parameter(
+                name = "name",
+                in = ParameterIn.QUERY,
+                description = "상품명으로 검색 (선택)",
+                required = false
+        ),
+        @Parameter(
+                name = "page",
+                in = ParameterIn.QUERY,
+                description = "페이지 번호 (0부터 시작)",
+                required = false
+        ),
+        @Parameter(
+                name = "size",
+                in = ParameterIn.QUERY,
+                description = "페이지 크기 (기본값: 10)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "상품 목록 조회 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 상품 목록 조회 성공",
+                                        description = "상품 목록이 정상적으로 조회된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": {
+                                                    "content": [
+                                                      {
+                                                        "id": 1,
+                                                        "code": "PRD001",
+                                                        "name": "상품명",
+                                                        "price": 10000,
+                                                        "inventory": 100,
+                                                        "status": "ACTIVE"
+                                                      }
+                                                    ],
+                                                    "totalElements": 1,
+                                                    "totalPages": 1,
+                                                    "size": 10,
+                                                    "number": 0
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductListApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateApiResponse.java
@@ -1,0 +1,181 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.product.model.dto.request.ProductCreateRequest;
+import com.ll.products.domain.product.model.dto.request.ProductUpdateRequest;
+import com.ll.products.domain.product.model.dto.response.ProductResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 정보 수정",
+        description = """
+                상품의 정보를 수정합니다.
+                
+                - 판매자는 본인의 상품만 수정 가능합니다.
+                - 관리자는 모든 상품을 수정할 수 있습니다.
+                - 상품명, 설명, 가격 등의 정보를 수정할 수 있습니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "code",
+                in = ParameterIn.PATH,
+                description = "상품 코드",
+                required = true
+        ),
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        ),
+        @Parameter(
+                name = "X-Role",
+                in = ParameterIn.HEADER,
+                description = "사용자 권한",
+                required = true,
+                example = "SELLER"
+        )
+})
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ProductUpdateRequest.class),
+                examples = {
+                        @ExampleObject(
+                                name = "상품 수정 요청",
+                                value = """
+                                        {
+                                        "name": "해리포터 안경(모조품)",
+                                        "categoryId": 21,
+                                        "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품(중요),",
+                                        "price": 10000,
+                                        "quantity": 3,
+                                        "addImages": [
+                                        {
+                                        "fileKey": "imageFileKeyExample.",
+                                        "sequence": 1,
+                                        "isMain" : true
+                                        }
+                                        ],
+                                        "deleteImageKeys":[
+                                        "fileKeyExample"
+                                        ]
+                                        }
+                                        """
+                        )
+                }
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "상품 수정 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ProductResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 상품 수정 성공",
+                                        description = "상품 정보가 정상적으로 수정된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": {
+                                                    "id": 1,
+                                                    "code": "PRD001",
+                                                    "name": "수정된 상품명",
+                                                    "description": "수정된 상품 설명",
+                                                    "price": 15000,
+                                                    "inventory": 100,
+                                                    "status": "ACTIVE"
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - 필수 필드 누락",
+                                        description = "필수 입력값이 누락된 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "필수 필드가 누락되었습니다.",
+                                                  "errorCode": "INVALID_INPUT"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "403 - 권한 없음",
+                                        description = "본인의 상품이 아니거나 권한이 없는 경우",
+                                        value = """
+                                                {
+                                                  "status": 403,
+                                                  "message": "상품 수정 권한이 없습니다.",
+                                                  "errorCode": "FORBIDDEN"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "상품을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 상품 없음",
+                                        description = "해당 코드의 상품이 존재하지 않는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "상품을 찾을 수 없습니다.",
+                                                  "errorCode": "PRODUCT_NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductUpdateApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateApiResponse.java
@@ -89,7 +89,7 @@ import java.lang.annotation.*;
                 description = "상품 수정 성공",
                 content = @Content(
                         mediaType = "application/json",
-                        schema = @Schema(implementation = ProductResponse.class),
+                        schema = @Schema(implementation = BaseResponse.class),
                         examples = {
                                 @ExampleObject(
                                         name = "200 - 상품 수정 성공",
@@ -104,7 +104,7 @@ import java.lang.annotation.*;
                                                     "name": "수정된 상품명",
                                                     "description": "수정된 상품 설명",
                                                     "price": 15000,
-                                                    "inventory": 100,
+                                                    "quantity": 100,
                                                     "status": "ACTIVE"
                                                   }
                                                 }

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateInventoryApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateInventoryApiResponse.java
@@ -1,0 +1,119 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.product.model.dto.request.ProductUpdateInventoryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 재고 변동",
+        description = """
+                상품의 재고를 증가 또는 감소시킵니다.
+                
+                - 양수 입력 시 재고 증가, 음수 입력 시 재고 감소
+                - 동시성 제어를 위해 비관적 락을 사용합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "code",
+                in = ParameterIn.PATH,
+                description = "상품 코드",
+                required = true
+        )
+})
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ProductUpdateInventoryRequest.class),
+                examples = {
+                        @ExampleObject(
+                                name = "상품 재고 변경 요청",
+                                value = """
+                                        {
+                                        "quantity": -1
+                                        }
+                                        """
+                        )
+                }
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "재고 변동 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 재고 변동 성공",
+                                        description = "재고가 정상적으로 변동된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - 재고 부족",
+                                        description = "재고가 부족하여 감소할 수 없는 경우",
+                                        value = """
+                                                {
+                                                  "status": 422,
+                                                  "message": "재고가 부족합니다. 상품코드: 019b24c1-6722-7834-aec5-e01db54c6acb, 현재재고: 2",
+                                                  "errorCode": "INSUFFICIENT_INVENTORY"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "상품을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 상품 없음",
+                                        description = "해당 코드의 상품이 존재하지 않는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "상품을 찾을 수 없습니다. 상품코드: 019b24c1-6722-7834-aec5-e01db54c6acba",
+                                                  "errorCode": "NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductUpdateInventoryApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateInventoryApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateInventoryApiResponse.java
@@ -73,14 +73,14 @@ import java.lang.annotation.*;
                 )
         ),
         @ApiResponse(
-                responseCode = "400",
+                responseCode = "422",
                 description = "잘못된 요청",
                 content = @Content(
                         mediaType = "application/json",
                         schema = @Schema(implementation = BaseResponse.class),
                         examples = {
                                 @ExampleObject(
-                                        name = "400 - 재고 부족",
+                                        name = "422 - 재고 부족",
                                         description = "재고가 부족하여 감소할 수 없는 경우",
                                         value = """
                                                 {

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateStatusApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateStatusApiResponse.java
@@ -26,7 +26,7 @@ import java.lang.annotation.*;
                 
                 - 판매자는 본인의 상품 상태만 변경 가능합니다.
                 - 관리자는 모든 상품의 상태를 변경할 수 있습니다.
-                - 상태: ACTIVE, INACTIVE, DELETED
+                - 상태: WAITING, ON_SALE, SOLD_OUT
                 """
 )
 @Parameters({

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateStatusApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateStatusApiResponse.java
@@ -1,0 +1,172 @@
+package com.ll.products.domain.product.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import com.ll.products.domain.product.model.dto.request.ProductUpdateStatusRequest;
+import com.ll.products.domain.product.model.dto.response.ProductResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상품 상태 변경",
+        description = """
+                상품의 상태를 변경합니다.
+                
+                - 판매자는 본인의 상품 상태만 변경 가능합니다.
+                - 관리자는 모든 상품의 상태를 변경할 수 있습니다.
+                - 상태: ACTIVE, INACTIVE, DELETED
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "code",
+                in = ParameterIn.PATH,
+                description = "상품 코드",
+                required = true
+        ),
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        )
+})
+@RequestBody(
+        required = true,
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ProductUpdateStatusRequest.class),
+                examples = {
+                        @ExampleObject(
+                                name = "상품 상태 변경 요청",
+                                value = """
+                                        {
+                                        "status": "ON_SALE"
+                                        }
+                                        """
+                        )
+                }
+        )
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "상품 상태 변경 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ProductResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 상품 상태 변경 성공",
+                                        description = "상품 상태가 정상적으로 변경된 경우",
+                                        value = """
+                                                {
+                                                  "status": 200,
+                                                  "message": "success",
+                                                  "data": {
+                                                    "id": 1,
+                                                    "code": "019b24c1-6722-7834-aec5-e01db54c6acb",
+                                                    "name": "해리포터 안경(모조품)",
+                                                    "categoryId": 21,
+                                                    "categoryName": "해리포터",
+                                                    "sellerCode": "019a90ab-fcf3-7413-af08-7121cc99378b",
+                                                    "sellerName": "알 수 없는 판매자",
+                                                    "status": "ON_SALE",
+                                                    "quantity": 3,
+                                                    "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품(중요),",
+                                                    "price": 10000,
+                                                    "images": [
+                                                      {
+                                                        "url": "https://team-404-bucket.s3.ap-northeast-2.amazonaws.com/imageFileKeyExample.",
+                                                        "sequence": 1,
+                                                        "isMain": true
+                                                      }
+                                                    ],
+                                                    "createdAt": "2025-12-16T10:23:33.283724",
+                                                    "updatedAt": "2025-12-16T10:24:34.246603"
+                                                  }
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - 유효하지 않은 상태값",
+                                        description = "유효하지 않은 상태값이 입력된 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "유효하지 않은 상태값입니다.",
+                                                  "errorCode": "INVALID_STATUS"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "403 - 권한 없음",
+                                        description = "본인의 상품이 아닌 경우",
+                                        value = """
+                                                {
+                                                  "status": 403,
+                                                  "message": "상품에 대한 권한이 없습니다. 상품코드: 019b24c1-6722-7834-aec5-e01db54c6acb",
+                                                  "errorCode": "FORBIDDEN"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "상품을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 상품 없음",
+                                        description = "해당 코드의 상품이 존재하지 않는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "상품을 찾을 수 없습니다. 상품코드: 019b24c1-6722-7834-aec5-e01db54c6acbs",
+                                                  "errorCode": "NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ProductUpdateStatusApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateStatusApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/swagger/ProductUpdateStatusApiResponse.java
@@ -67,7 +67,7 @@ import java.lang.annotation.*;
                 description = "상품 상태 변경 성공",
                 content = @Content(
                         mediaType = "application/json",
-                        schema = @Schema(implementation = ProductResponse.class),
+                        schema = @Schema(implementation = BaseResponse.class),
                         examples = {
                                 @ExampleObject(
                                         name = "200 - 상품 상태 변경 성공",

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/RecommendationController.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/RecommendationController.java
@@ -1,7 +1,10 @@
 package com.ll.products.domain.recommendation.controller;
 
+import com.ll.products.domain.recommendation.controller.swagger.*;
 import com.ll.products.domain.recommendation.dto.RecommendationResponse;
 import com.ll.products.domain.recommendation.service.RecommendationService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Recommendation", description = "상품 추천 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/products/recommendations")
@@ -19,6 +23,7 @@ public class RecommendationController {
 
     // 1. 유사한 상품 추천
     @GetMapping("/similar/{productCode}")
+    @SimilarProductsApiResponse
     public ResponseEntity<List<RecommendationResponse>> getSimilarProducts(
             @PathVariable String productCode,
             @RequestParam(defaultValue = "10") int limit
@@ -34,6 +39,7 @@ public class RecommendationController {
 
     // 2. 검색어 기반 상품 추천
     @GetMapping("/search")
+    @SearchRecommendationsApiResponse
     public ResponseEntity<List<RecommendationResponse>> searchRecommendations(
             @RequestParam String keyword,
             @RequestParam(defaultValue = "10") int limit
@@ -50,6 +56,7 @@ public class RecommendationController {
 
     // 3. 유저 상세 조회 기록 기반 상품 추천
     @GetMapping("/view-history")
+    @ViewHistoryRecommendationsApiResponse
     public ResponseEntity<List<RecommendationResponse>> recommendationsFromViewHistory(
             @RequestHeader("X-User-Code") String userCode,
             @RequestParam(defaultValue = "10") int limit
@@ -60,6 +67,7 @@ public class RecommendationController {
 
     // 4. 유저 검색 기록 기반 상품 추천
     @GetMapping("/search-history")
+    @SearchHistoryRecommendationsApiResponse
     public ResponseEntity<List<RecommendationResponse>> recommendationsFromSearchHistory(
             @RequestHeader("X-User-Code") String userCode,
             @RequestParam(defaultValue = "10") int limit
@@ -70,6 +78,7 @@ public class RecommendationController {
 
     // 5. 전체 상품 재색인 (관리자용)
     @PostMapping("/reindex")
+    @ReindexAllProductsApiResponse
     public ResponseEntity<String> reindexAllProducts() {
         log.info("전체 상품 재색인 요청");
         recommendationService.reindexAllProducts();
@@ -78,6 +87,7 @@ public class RecommendationController {
 
     // 6. 상세 조회 기록 및 llm 기반
     @GetMapping("/view-history/llm")
+    @LlmRecommendationsApiResponse
     public ResponseEntity<List<RecommendationResponse>> recommendationsWithLlm(
             @RequestHeader("X-User-Code") String userCode,
             @RequestParam(defaultValue = "10") int limit

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/LlmRecommendationsApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/LlmRecommendationsApiResponse.java
@@ -1,0 +1,75 @@
+package com.ll.products.domain.recommendation.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "LLM 기반 상품 추천",
+        description = """
+                LLM(Large Language Model)을 활용하여 사용자의 조회 기록을 분석하고 상품을 추천합니다.
+
+                - 사용자의 조회 기록을 LLM이 분석하여 맥락을 파악합니다.
+                - 더 정교하고 맥락을 고려한 추천을 제공합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        ),
+        @Parameter(
+                name = "limit",
+                in = ParameterIn.QUERY,
+                description = "추천 결과 개수 (기본값: 10)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "LLM 기반 추천 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - LLM 기반 추천 성공",
+                                        description = "추천 결과가 정상적으로 조회된 경우",
+                                        value = """
+                                                [
+                                                  {
+                                                    "productCode": "PRD001",
+                                                    "productName": "추천 상품 1",
+                                                    "price": 10000,
+                                                    "score": 0.96
+                                                  },
+                                                  {
+                                                    "productCode": "PRD002",
+                                                    "productName": "추천 상품 2",
+                                                    "price": 12000,
+                                                    "score": 0.93
+                                                  }
+                                                ]
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface LlmRecommendationsApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/ReindexAllProductsApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/ReindexAllProductsApiResponse.java
@@ -1,0 +1,42 @@
+package com.ll.products.domain.recommendation.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "전체 상품 재색인",
+        description = """
+                Elasticsearch의 모든 상품 데이터를 재색인합니다 (관리자용).
+
+                - 데이터베이스의 모든 상품 정보를 Elasticsearch에 다시 저장합니다.
+                - 검색 성능 개선 또는 데이터 동기화가 필요할 때 사용합니다.
+                """
+)
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "재색인 시작 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 재색인 시작 성공",
+                                        description = "재색인 작업이 정상적으로 시작된 경우",
+                                        value = """
+                                                "전체 상품 재색인이 시작되었습니다."
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ReindexAllProductsApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/SearchHistoryRecommendationsApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/SearchHistoryRecommendationsApiResponse.java
@@ -1,0 +1,96 @@
+package com.ll.products.domain.recommendation.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "검색 기록 기반 상품 추천",
+        description = """
+                사용자의 검색 기록을 기반으로 관심있을 만한 상품을 추천합니다.
+
+                - 최근 검색 키워드를 분석하여 관련 상품을 추천합니다.
+                - 사용자의 검색 의도를 파악하여 맞춤형 추천을 제공합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        ),
+        @Parameter(
+                name = "limit",
+                in = ParameterIn.QUERY,
+                description = "추천 결과 개수 (기본값: 10)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "검색 기록 기반 추천 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 검색 기록 기반 추천 성공",
+                                        description = "추천 결과가 정상적으로 조회된 경우",
+                                        value = """
+                                                [
+                                                  {
+                                                    "productCode": "PRD001",
+                                                    "productName": "추천 상품 1",
+                                                    "price": 10000,
+                                                    "score": 0.94
+                                                  },
+                                                  {
+                                                    "productCode": "PRD002",
+                                                    "productName": "추천 상품 2",
+                                                    "price": 12000,
+                                                    "score": 0.91
+                                                  }
+                                                ]
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - 사용자 코드 누락",
+                                        description = "사용자 코드가 제공되지 않은 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "사용자 코드가 필요합니다.",
+                                                  "errorCode": "USER_CODE_REQUIRED"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface SearchHistoryRecommendationsApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/SearchRecommendationsApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/SearchRecommendationsApiResponse.java
@@ -1,0 +1,69 @@
+package com.ll.products.domain.recommendation.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "검색어 기반 상품 추천",
+        description = """
+                검색 키워드를 기반으로 관련 상품을 추천합니다.
+                
+                - 키워드와 관련도가 높은 상품들을 찾습니다.
+                - Elasticsearch를 활용한 전문 검색을 수행합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "keyword",
+                in = ParameterIn.QUERY,
+                description = "검색 키워드",
+                required = true
+        ),
+        @Parameter(
+                name = "limit",
+                in = ParameterIn.QUERY,
+                description = "추천 결과 개수 (기본값: 10)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "검색어 기반 추천 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 검색어 기반 추천 성공",
+                                        description = "검색 결과가 정상적으로 조회된 경우",
+                                        value = """
+                                                [
+                                                  {
+                                                    "productCode": "019b24c1-6722-7834-aec5-e01db54c6acb",
+                                                    "name": "해리포터 안경(모조품)",
+                                                    "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품(중요),",
+                                                    "categoryName": "해리포터",
+                                                    "price": 10000,
+                                                    "status": "ON_SALE",
+                                                    "score": 0.27883434
+                                                  }
+                                                ]
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface SearchRecommendationsApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/SimilarProductsApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/SimilarProductsApiResponse.java
@@ -1,0 +1,89 @@
+package com.ll.products.domain.recommendation.controller.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "유사한 상품 추천",
+        description = """
+                특정 상품과 유사한 다른 상품들을 추천합니다.
+                
+                - 상품 코드를 기반으로 유사한 상품을 찾습니다.
+                - Elasticsearch를 활용한 벡터 유사도 검색을 수행합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "productCode",
+                in = ParameterIn.PATH,
+                description = "상품 코드",
+                required = true
+        ),
+        @Parameter(
+                name = "limit",
+                in = ParameterIn.QUERY,
+                description = "추천 결과 개수 (기본값: 10)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "유사 상품 추천 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 유사 상품 추천 성공",
+                                        description = "유사 상품이 정상적으로 조회된 경우",
+                                        value = """
+                                                [
+                                                  {
+                                                    "productCode": "019b24c1-6722-7834-aec5-e01db54c6acb",
+                                                    "name": "해리포터 안경(모조품)",
+                                                    "description": "미개봉 새상품. 해리포터 마법사의 돌에서 해리가 착용했던 안경의 모조품(중요),",
+                                                    "categoryName": "해리포터",
+                                                    "price": 10000,
+                                                    "status": "ON_SALE",
+                                                    "score": 0.27883434
+                                                  }
+                                                ]
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "404",
+                description = "상품을 찾을 수 없음",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "404 - 상품 없음",
+                                        description = "해당 코드의 상품이 존재하지 않는 경우",
+                                        value = """
+                                                {
+                                                  "status": 404,
+                                                  "message": "상품을 찾을 수 없습니다.",
+                                                  "errorCode": "PRODUCT_NOT_FOUND"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface SimilarProductsApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/ViewHistoryRecommendationsApiResponse.java
+++ b/products/src/main/java/com/ll/products/domain/recommendation/controller/swagger/ViewHistoryRecommendationsApiResponse.java
@@ -1,0 +1,96 @@
+package com.ll.products.domain.recommendation.controller.swagger;
+
+import com.ll.core.model.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Operation(
+        summary = "상세 조회 기록 기반 상품 추천",
+        description = """
+                사용자의 상품 상세 조회 기록을 기반으로 관심있을 만한 상품을 추천합니다.
+
+                - 최근 조회한 상품들과 유사한 상품을 추천합니다.
+                - 사용자 행동 패턴을 분석하여 개인화된 추천을 제공합니다.
+                """
+)
+@Parameters({
+        @Parameter(
+                name = "X-User-Code",
+                in = ParameterIn.HEADER,
+                description = "사용자 코드",
+                required = true,
+                example = "019a90ab-fcf3-7413-af08-7121cc99378b"
+        ),
+        @Parameter(
+                name = "limit",
+                in = ParameterIn.QUERY,
+                description = "추천 결과 개수 (기본값: 10)",
+                required = false
+        )
+})
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "조회 기록 기반 추천 성공",
+                content = @Content(
+                        mediaType = "application/json",
+                        examples = {
+                                @ExampleObject(
+                                        name = "200 - 조회 기록 기반 추천 성공",
+                                        description = "추천 결과가 정상적으로 조회된 경우",
+                                        value = """
+                                                [
+                                                  {
+                                                    "productCode": "PRD001",
+                                                    "productName": "추천 상품 1",
+                                                    "price": 10000,
+                                                    "score": 0.92
+                                                  },
+                                                  {
+                                                    "productCode": "PRD002",
+                                                    "productName": "추천 상품 2",
+                                                    "price": 12000,
+                                                    "score": 0.89
+                                                  }
+                                                ]
+                                                """
+                                )
+                        }
+                )
+        ),
+        @ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = BaseResponse.class),
+                        examples = {
+                                @ExampleObject(
+                                        name = "400 - 사용자 코드 누락",
+                                        description = "사용자 코드가 제공되지 않은 경우",
+                                        value = """
+                                                {
+                                                  "status": 400,
+                                                  "message": "사용자 코드가 필요합니다.",
+                                                  "errorCode": "USER_CODE_REQUIRED"
+                                                }
+                                                """
+                                )
+                        }
+                )
+        )
+})
+public @interface ViewHistoryRecommendationsApiResponse {
+}

--- a/products/src/main/java/com/ll/products/domain/s3/controller/S3Controller.java
+++ b/products/src/main/java/com/ll/products/domain/s3/controller/S3Controller.java
@@ -3,10 +3,13 @@ package com.ll.products.domain.s3.controller;
 import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.s3.model.dto.response.PresignedUrlResponse;
 import com.ll.products.domain.s3.service.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Image", description = "S3 관련 API")
 @RestController
 @RequestMapping("/api/images")
 @RequiredArgsConstructor
@@ -14,7 +17,7 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    // 1. presigned url 생성
+    @Operation(summary = "presigned url 생성")
     @GetMapping("/presigned-url")
     public ResponseEntity<BaseResponse<PresignedUrlResponse>> getPresignedUploadUrl(
             @RequestParam("filename") String filename
@@ -22,12 +25,12 @@ public class S3Controller {
         return BaseResponse.ok(s3Service.generatePresignedUploadUrl(filename));
     }
 
-    // 2. 이미지 파일 삭제
-    @DeleteMapping
-    public ResponseEntity<BaseResponse<Void>> deleteImage(
-            @RequestParam("fileKey") String fileKey
-    ) {
-        s3Service.deleteImage(fileKey);
-        return BaseResponse.ok(null);
-    }
+//    @Operation(summary = "imageFile 삭제")
+//    @DeleteMapping
+//    public ResponseEntity<BaseResponse<Void>> deleteImage(
+//            @RequestParam("fileKey") String fileKey
+//    ) {
+//        s3Service.deleteImage(fileKey);
+//        return BaseResponse.ok(null);
+//    }
 }

--- a/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
+++ b/products/src/main/java/com/ll/products/domain/search/controller/ProductSearchController.java
@@ -3,6 +3,9 @@ import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.history.service.HistoryFacadeService;
 import com.ll.products.domain.search.dto.ProductSearchResponse;
 import com.ll.products.domain.search.service.ProductSearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -11,6 +14,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Search", description = "상품 검색 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/products")
@@ -20,6 +24,9 @@ public class ProductSearchController {
     private final ProductSearchService productSearchService;
     private final HistoryFacadeService historyFacadeService;
 
+    @Operation(
+            summary = "상품 목록 검색"
+    )
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<Page<ProductSearchResponse>>> search(
             @RequestParam(required = false) String keyword,
@@ -27,8 +34,8 @@ public class ProductSearchController {
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String status,
-            @RequestHeader(value = "X-User-Code",required = false ) String userCode,
-            @PageableDefault(size = 20) Pageable pageable
+            @RequestHeader(value = "X-User-Code", required = false ) String userCode,
+            @ParameterObject() @PageableDefault(size = 20) Pageable pageable
     ) {
         if(userCode != null){
             historyFacadeService.saveSearch(userCode,keyword);


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
--- 상품 모듈 스웨거 작성
- 상품, 카테고리, 장바구니, S3, 추천, 검색 API에 대한 스웨거 작성

🔗 관련 이슈
---[[product][docs] product swagger 작성]
- 관련 이슈 번호: #220

📋 요구 사항과 구현 내용
--- 상품 모듈 전체 스웨거 작성
- 상품 및 상품 추천 API는 중요도가 높아 자세히 작성
- 기타 나머지 API는 간단하게 작성

💬 TODO 리스트
--- 
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등










<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Product 도메인 Swagger 메타 어노테이션 도입 및 Controller 적용 
 - `ProductController`에 `@Tag(name = "Product")` 추가 및 각 엔드포인트에 전용 Swagger 어노테이션(`@ProductCreateApiResponse`, `@ProductGetApiResponse`, `@ProductListApiResponse`, `@ProductDeleteApiResponse`, `@ProductUpdateApiResponse`, `@ProductUpdateStatusApiResponse`, `@ProductUpdateInventoryApiResponse`) 부착 
 - `product/controller/swagger` 패키지에 위 전용 어노테이션들을 신규 정의하여 `@Operation`, `@Parameters`, `@RequestBody`, `@ApiResponses` 및 상세 example payload를 중앙집중식으로 관리 

2. Recommendation 도메인 Swagger 문서화 확장 
 - `RecommendationController`에 `@Tag(name = "Recommendation")` 추가 및 모든 엔드포인트에 전용 Swagger 어노테이션(`@SimilarProductsApiResponse`, `@SearchRecommendationsApiResponse`, `@ViewHistoryRecommendationsApiResponse`, `@SearchHistoryRecommendationsApiResponse`, `@ReindexAllProductsApiResponse`, `@LlmRecommendationsApiResponse`) 적용 
 - 각 어노테이션에서 path/query/header 파라미터와 응답 예시(JSON 배열/문자열 등)를 정의하여 추천 API 스펙을 명시 

3. Cart, Category, Search, S3 컨트롤러 기본 Swagger 태깅 및 Operation 추가 
 - `CartController`, `CategoryController`, `ProductSearchController`, `S3Controller`에 각각 `@Tag` 추가로 도메인별 그룹화 
 - Cart, Category, Search, S3의 주요 엔드포인트에 `@Operation(summary = ...)` 추가하여 목적을 문서화 
 - `ProductSearchController.search`에서 `@ParameterObject`를 `Pageable`에 적용하고 `X-User-Code` 헤더 포맷팅 수정 

4. S3 이미지 삭제 엔드포인트 비활성화 
 - `S3Controller`의 `@DeleteMapping` 기반 `deleteImage` 메서드를 전체 주석 처리하여 API에서 제거 (Swagger 문서 주석 포함)
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. S3 이미지 삭제 API 제거로 인한 기능 상실 가능성
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `S3Controller`에서 `@DeleteMapping` deleteImage 엔드포인트 전체를 주석 처리하여 외부에서 이미지 삭제를 호출할 수 없게 변경됨.
 - products/src/main/java/com/ll/products/domain/s3/controller/S3Controller.java:
 ```java
 // @Operation(summary = "imageFile 삭제")
 // @DeleteMapping
 // public ResponseEntity<BaseResponse<Void>> deleteImage(
 // @RequestParam("fileKey") String fileKey
 // ) {
 // s3Service.deleteImage(fileKey);
 // return BaseResponse.ok(null);
 // }
 ```
 - 결과: 기존에 이 엔드포인트를 통해 S3 이미지 정리를 하던 클라이언트/관리자 기능이 더 이상 동작하지 않으며, 애플리케이션 레벨에서 이미지 삭제 경로가 사라짐.
 - 위험성: 사용되지 않는 이미지가 S3에 누적되어 스토리지 비용 증가 및 데이터 정리 불가 상황(운영 장애는 아니지만 운영·비용 측면의 실질적 문제)을 유발할 수 있음.
<!-- AI-REVIEW:END -->