### PR TITLE
[feat][235] 예치금 충전용 UI, 로직 추가 구현

### DIFF
--- a/order/src/main/java/com/ll/order/domain/client/DepositServiceClient.java
+++ b/order/src/main/java/com/ll/order/domain/client/DepositServiceClient.java
@@ -1,0 +1,70 @@
+package com.ll.order.domain.client;
+
+import com.ll.core.model.exception.BaseException;
+import com.ll.order.domain.exception.OrderErrorCode;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DepositServiceClient {
+
+    private final RestClient restClient;
+
+    @Value("${external.payment-service.url:http://localhost:8087}")
+    private String paymentServiceUrl;
+
+    @CircuitBreaker(name = "paymentService", fallbackMethod = "chargeDepositFallback")
+    @Retry(name = "paymentService")
+    public void chargeDeposit(String userCode, Long amount, String referenceCode) {
+        String url = paymentServiceUrl + "/api/deposits/charge";
+        Map<String, Object> request = Map.of(
+                "amount", amount,
+                "referenceCode", referenceCode
+        );
+        
+        restClient.post()
+                .uri(url)
+                .header("X-User-Code", userCode)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+        
+        log.debug("예치금 충전 API 호출 완료 - userCode: {}, amount: {}, referenceCode: {}", 
+                userCode, amount, referenceCode);
+    }
+
+    // chargeDeposit 실패 시
+    private void chargeDepositFallback(String userCode, Long amount, String referenceCode, Throwable e) {
+        log.error("예치금 충전 실패 (재시도 모두 실패) - userCode: {}, amount: {}, referenceCode: {}, error: {}",
+                userCode, amount, referenceCode, extractMessage(e), e);
+        throw new BaseException(OrderErrorCode.PAYMENT_PROCESSING_FAILED,
+                "예치금 충전 실패: " + extractMessage(e));
+    }
+
+    private String extractMessage(Throwable e) {
+        if (e instanceof HttpClientErrorException http4xx) {
+            HttpStatusCode status = http4xx.getStatusCode();
+            return "status=" + status + ", body=" + http4xx.getResponseBodyAsString();
+        }
+        if (e instanceof HttpServerErrorException http5xx) {
+            HttpStatusCode status = http5xx.getStatusCode();
+            return "status=" + status + ", body=" + http5xx.getResponseBodyAsString();
+        }
+        return e.getMessage();
+    }
+}
+

--- a/order/src/main/java/com/ll/order/domain/client/PaymentServiceClient.java
+++ b/order/src/main/java/com/ll/order/domain/client/PaymentServiceClient.java
@@ -26,12 +26,6 @@ public class PaymentServiceClient {
     @Value("${external.payment-service.url:http://localhost:8087}")
     private String paymentServiceUrl;
 
-    /**
-     * 예치금 결제 요청
-     * - Resilience4j Retry + CircuitBreaker 적용
-     * - 네트워크/5xx 오류 시 최대 n회 재시도 (설정 기반)
-     * - 실패율이 높아지면 Circuit Open 상태에서 빠른 실패
-     */
     @CircuitBreaker(name = "paymentService", fallbackMethod = "depositPaymentFallback")
     @Retry(name = "paymentService")
     public String requestDepositPayment(OrderPaymentRequest request) {
@@ -48,6 +42,30 @@ public class PaymentServiceClient {
     @Retry(name = "paymentService")
     public void requestTossPayment(OrderPaymentRequest request) {
         String url = paymentServiceUrl + "/api/payments/toss";
+        restClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(String.class);
+    }
+
+    @CircuitBreaker(name = "paymentService", fallbackMethod = "tossPaymentForChargeFallback")
+    @Retry(name = "paymentService")
+    public void requestTossPaymentForCharge(Object request) {
+        String url = paymentServiceUrl + "/api/payments/toss";
+        restClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(String.class);
+    }
+
+    @CircuitBreaker(name = "paymentService", fallbackMethod = "depositChargeTossFallback")
+    @Retry(name = "paymentService")
+    public void requestDepositChargeWithToss(OrderPaymentRequest request) {
+        String url = paymentServiceUrl + "/api/payments/deposit/charge";
         restClient.post()
                 .uri(url)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -89,11 +107,23 @@ public class PaymentServiceClient {
                 "토스 결제 요청 실패: " + extractMessage(e));
     }
 
+    // requestTossPaymentForCharge 실패 시
+    private void tossPaymentForChargeFallback(Object request, Throwable e) {
+        throw new BaseException(OrderErrorCode.PAYMENT_PROCESSING_FAILED,
+                "예치금 충전용 토스 결제 요청 실패: " + extractMessage(e));
+    }
+
     // requestRefund 실패 시
     private void refundFallback(Long orderId, String orderCode, String buyerCode,
                                 Integer refundAmount, String reason, Throwable e) {
         throw new BaseException(OrderErrorCode.PAYMENT_PROCESSING_FAILED,
                 "환불 요청 실패: " + extractMessage(e));
+    }
+
+    // requestDepositChargeWithToss 실패 시
+    private void depositChargeTossFallback(OrderPaymentRequest request, Throwable e) {
+        throw new BaseException(OrderErrorCode.PAYMENT_PROCESSING_FAILED,
+                "예치금 충전 실패: " + extractMessage(e));
     }
 
     private String extractMessage(Throwable e) {

--- a/order/src/main/java/com/ll/order/domain/controller/OrderController.java
+++ b/order/src/main/java/com/ll/order/domain/controller/OrderController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
+import jakarta.servlet.http.HttpSession;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -23,7 +24,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor
-public class OrderController implements OrderControllerSwagger { // TODO : 예치금 부족 시 토스로 예치금 충전
+public class OrderController implements OrderControllerSwagger {
 
     private final OrderService orderService;
 
@@ -124,6 +125,59 @@ public class OrderController implements OrderControllerSwagger { // TODO : 예�
                 (errorCode != null ? errorCode : "") +
                 "&errorMessage=" + (errorMessage != null ? errorMessage : "") +
                 "&orderId=" + (orderId != null ? orderId : ""));
+    }
+
+    @GetMapping("/deposit/charge/success")
+    public RedirectView depositChargeSuccess(
+            @RequestParam String paymentKey,
+            @RequestParam("orderId") String orderId,
+            @RequestParam String amount,
+            HttpSession session
+    ) {
+        try {
+            // 세션에서 userCode 가져오기
+            String userCode = (String) session.getAttribute("depositChargeUserCode");
+            if (userCode == null) {
+                throw new IllegalArgumentException("사용자 코드를 찾을 수 없습니다. 세션이 만료되었을 수 있습니다.");
+            }
+            
+            orderService.completeDepositChargeWithKey(userCode, paymentKey, Integer.parseInt(amount), orderId);
+            
+            // 세션에서 userCode 제거
+            session.removeAttribute("depositChargeUserCode");
+            
+            return new RedirectView(currentDomain + "/orders/deposit/charge/success-page?amount=" + amount);
+        } catch (Exception e) {
+            String encodedErrorMessage = URLEncoder.encode(e.getMessage(), StandardCharsets.UTF_8);
+            return new RedirectView(currentDomain + "/orders/deposit/charge/fail-page?error=" + encodedErrorMessage);
+        }
+    }
+
+    @GetMapping("/deposit/charge/fail")
+    public RedirectView depositChargeFail(
+            @RequestParam(required = false) String errorCode,
+            @RequestParam(required = false) String errorMessage
+    ) {
+        return new RedirectView(currentDomain + "/orders/deposit/charge/fail-page?errorCode=" +
+                (errorCode != null ? errorCode : "") +
+                "&errorMessage=" + (errorMessage != null ? errorMessage : ""));
+    }
+
+    @PostMapping("/deposit/charge")
+    public RedirectView initiateDepositCharge(
+            @RequestBody Map<String, Object> request,
+            @RequestHeader("X-User-Code") String userCode
+    ) {
+        Integer amount = (Integer) request.get("amount");
+        if (amount == null || amount <= 0) {
+            throw new IllegalArgumentException("충전 금액은 0보다 커야 합니다.");
+        }
+        
+        // 토스 결제 페이지로 리다이렉트
+        String redirectUrl = String.format(currentDomain + "/orders/deposit/charge?amount=%d&userCode=%s",
+                amount,
+                URLEncoder.encode(userCode, StandardCharsets.UTF_8));
+        return new RedirectView(redirectUrl);
     }
 
 }

--- a/order/src/main/java/com/ll/order/domain/controller/OrderControllerSwagger.java
+++ b/order/src/main/java/com/ll/order/domain/controller/OrderControllerSwagger.java
@@ -8,6 +8,7 @@ import com.ll.order.domain.model.vo.response.order.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -114,6 +115,32 @@ public interface OrderControllerSwagger {
             @Parameter(description = "에러 코드") @RequestParam(required = false) String errorCode,
             @Parameter(description = "에러 메시지") @RequestParam(required = false) String errorMessage,
             @Parameter(description = "주문 ID") @RequestParam(required = false) String orderId
+    );
+
+    @Operation(
+            summary = "예치금 충전 성공 콜백",
+            description = """
+                    예치금 충전용 토스 결제 성공 시 토스 서버에서 자동으로 호출되는 콜백 엔드포인트입니다.
+                    결제 완료 처리 및 예치금 충전 후 성공 페이지로 리다이렉트됩니다.
+                    """
+    )
+    RedirectView depositChargeSuccess(
+            @RequestParam String paymentKey,
+            @RequestParam("orderId") String orderId,
+            @RequestParam String amount,
+            HttpSession session
+    );
+
+    @Operation(
+            summary = "예치금 충전 실패 콜백",
+            description = """
+                    예치금 충전용 토스 결제 실패 또는 취소 시 토스 서버에서 자동으로 호출되는 콜백 엔드포인트입니다.
+                    실패 페이지로 리다이렉트되며 에러 정보를 전달합니다.
+                    """
+    )
+    RedirectView depositChargeFail(
+            @Parameter(description = "에러 코드") @RequestParam(required = false) String errorCode,
+            @Parameter(description = "에러 메시지") @RequestParam(required = false) String errorMessage
     );
 }
 

--- a/order/src/main/java/com/ll/order/domain/controller/PaymentViewController.java
+++ b/order/src/main/java/com/ll/order/domain/controller/PaymentViewController.java
@@ -1,6 +1,7 @@
 package com.ll.order.domain.controller;
 
 import com.ll.order.domain.service.order.OrderService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
@@ -76,6 +77,53 @@ public class PaymentViewController {
     @GetMapping("/create-form")
     public String orderFormPage() {
         return "order-form";
+    }
+
+    // 예치금 충전 폼 페이지
+    @GetMapping("/deposit/charge-form")
+    public String depositChargeFormPage() {
+        return "deposit-charge-form";
+    }
+
+    // 예치금 충전 페이지 (토스 결제)
+    @GetMapping("/deposit/charge")
+    public String depositChargePage(
+            @RequestParam Integer amount,
+            @RequestParam String userCode,
+            @RequestParam(required = false, defaultValue = "고객") String customerName,
+            HttpSession session,
+            Model model
+    ) {
+        // 세션에 userCode 저장 (결제 성공 시 사용)
+        session.setAttribute("depositChargeUserCode", userCode);
+        
+        model.addAttribute("amount", amount);
+        model.addAttribute("customerName", customerName);
+        model.addAttribute("userCode", userCode);
+        model.addAttribute("clientKey", widgetClientKey);
+        model.addAttribute("successUrl", successUrl.replace("/payment/success", "/deposit/charge/success"));
+        model.addAttribute("failUrl", failUrl.replace("/payment/fail", "/deposit/charge/fail"));
+        return "deposit-charge";
+    }
+
+    @GetMapping("/deposit/charge/success-page")
+    public String depositChargeSuccessPage(
+            @RequestParam String amount,
+            Model model
+    ) {
+        model.addAttribute("amount", amount);
+        return "deposit-charge-success";
+    }
+
+    @GetMapping("/deposit/charge/fail-page")
+    public String depositChargeFailPage(
+            @RequestParam(required = false) String errorCode,
+            @RequestParam(required = false) String errorMessage,
+            Model model
+    ) {
+        model.addAttribute("errorCode", errorCode);
+        model.addAttribute("errorMessage", errorMessage);
+        return "deposit-charge-fail";
     }
 }
 

--- a/order/src/main/java/com/ll/order/domain/service/order/OrderService.java
+++ b/order/src/main/java/com/ll/order/domain/service/order/OrderService.java
@@ -28,6 +28,9 @@ public interface OrderService {
 //     paymentKey를 받아서 주문 결제를 완료 처리합니다.
     void completePaymentWithKey(String orderCode, String paymentKey);
 
+    // paymentKey를 받아서 예치금 충전을 완료 처리합니다.
+    void completeDepositChargeWithKey(String userCode, String paymentKey, Integer amount, String tossOrderId);
+
     String getOrderCodeById(Long orderId);
 
     // 결제 타입에 따라 리다이렉트 URL을 생성합니다. 리다이렉트가 필요하지 않은 경우 Optional.empty()를 반환합니다.

--- a/order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
+++ b/order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
@@ -3,6 +3,7 @@ package com.ll.order.domain.service.order;
 import com.ll.core.model.exception.BaseException;
 import com.ll.core.model.vo.kafka.RefundEvent;
 import com.ll.core.model.vo.kafka.PaymentRefundRequestEvent;
+import com.ll.order.domain.client.DepositServiceClient;
 import com.ll.order.domain.client.PaymentServiceClient;
 import com.ll.order.domain.client.ProductServiceClient;
 import com.ll.order.domain.client.UserServiceClient;
@@ -11,6 +12,7 @@ import com.ll.order.domain.model.entity.Order;
 import com.ll.order.domain.model.entity.OrderItem;
 import com.ll.order.domain.model.entity.history.OrderHistoryEntity;
 import com.ll.order.domain.model.enums.order.OrderStatus;
+import com.ll.order.domain.model.enums.order.OrderType;
 import com.ll.order.domain.model.enums.payment.PaidType;
 import com.ll.order.domain.model.enums.payment.PaymentRefundNotificationStatus;
 import com.ll.order.domain.model.vo.request.OrderCartItemRequest;
@@ -64,6 +66,7 @@ public class OrderServiceImpl implements OrderService {
     private final UserServiceClient userServiceClient;
     private final ProductServiceClient productServiceClient;
     private final PaymentServiceClient paymentApiClient;
+    private final DepositServiceClient depositServiceClient;
 
     private final OrderValidator orderValidator;
     
@@ -285,6 +288,60 @@ public class OrderServiceImpl implements OrderService {
 
             log.error("결제 처리 실패 - orderId: {}, paymentKey: {}, error: {}", orderCode, paymentKey, e.getMessage(), e);
             throw new BaseException(OrderErrorCode.PAYMENT_PROCESSING_FAILED);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void completeDepositChargeWithKey(String userCode, String paymentKey, Integer amount, String tossOrderId) {
+        try {
+            // 1. 사용자 정보 조회
+            UserResponse userInfo = getUserInfo(userCode);
+            
+            // 2. 예치금 충전용 Order 엔티티 생성
+            Order depositChargeOrder = Order.create(
+                    userInfo.id(), // buyerId
+                    userCode, // buyerCode
+                    OrderType.ONLINE, // orderType (예치금 충전은 온라인)
+                    "예치금 충전" // address (예치금 충전은 주소 불필요하지만 필수 필드)
+            );
+            Order savedOrder = orderJpaRepository.save(depositChargeOrder);
+            
+            // 3. 예치금 충전용 토스 결제 API 호출 (결제 승인 + 예치금 충전을 한 번에 처리)
+            // tossOrderId는 토스 결제 위젯에서 사용한 orderId로, 토스 API 승인 요청 시 동일한 값이 필요함
+            OrderPaymentRequest depositChargeRequest = new OrderPaymentRequest(
+                    savedOrder.getId(), // orderId
+                    tossOrderId, // orderCode (토스 결제 위젯에서 사용한 orderId 사용)
+                    savedOrder.getBuyerId(), // buyerId
+                    userCode, // buyerCode
+                    amount, // paidAmount
+                    PaidType.TOSS_PAYMENT, // paidType
+                    paymentKey // paymentKey
+            );
+            
+            // 4. /api/payments/deposit/charge 엔드포인트 호출 (토스 결제 승인 + 예치금 충전)
+            paymentApiClient.requestDepositChargeWithToss(depositChargeRequest);
+            
+            // 5. 주문 상태를 COMPLETED로 변경 (예치금 충전 완료)
+            savedOrder.changeStatus(OrderStatus.COMPLETED);
+            orderJpaRepository.save(savedOrder);
+            
+            // 6. 주문 이력 저장
+            OrderHistoryEntity orderHistory = OrderHistoryEntity.createPaymentSuccessHistory(
+                    savedOrder, 
+                    List.of(), // 예치금 충전은 OrderItem이 없음
+                    OrderStatus.CREATED, 
+                    "예치금 충전"
+            );
+            orderHistoryJpaRepository.save(orderHistory);
+            
+            log.debug("예치금 충전 완료 - orderId: {}, orderCode: {}, userCode: {}, amount: {}, paymentKey: {}", 
+                    savedOrder.getId(), savedOrder.getCode(), userCode, amount, paymentKey);
+            
+        } catch (Exception e) {
+            log.error("예치금 충전 실패 - userCode: {}, amount: {}, paymentKey: {}, error: {}", 
+                    userCode, amount, paymentKey, e.getMessage(), e);
+            throw new BaseException(OrderErrorCode.PAYMENT_PROCESSING_FAILED, "예치금 충전 실패: " + e.getMessage());
         }
     }
 

--- a/order/src/main/resources/templates/deposit-charge-fail.html
+++ b/order/src/main/resources/templates/deposit-charge-fail.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>예치금 충전 실패</title>
+</head>
+<body>
+    <div>
+        <h2>예치금 충전 실패</h2>
+        <p th:if="${errorCode}">에러 코드: <span th:text="${errorCode}"></span></p>
+        <p th:if="${errorMessage}">에러 메시지: <span th:text="${errorMessage}"></span></p>
+        <p>예치금 충전에 실패했습니다. 다시 시도해주세요.</p>
+    </div>
+</body>
+</html>
+

--- a/order/src/main/resources/templates/deposit-charge-form.html
+++ b/order/src/main/resources/templates/deposit-charge-form.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>예치금 충전</title>
+</head>
+<body>
+    <div class="container">
+        <h2>예치금 충전</h2>
+        <form id="depositChargeForm">
+            <div class="form-group">
+                <label for="userCode">사용자 코드 (User Code) *</label>
+                <input type="text" id="userCode" name="userCode" required value="USER-001" placeholder="예: USER-001">
+                <small class="error">이 값은 X-User-Code 헤더로 서버에 전달됩니다.</small>
+            </div>
+            
+            <div class="form-group">
+                <label for="amount">충전 금액 *</label>
+                <input type="number" id="amount" name="amount" min="1" required value="50000" placeholder="충전할 금액을 입력하세요">
+            </div>
+
+            <button type="submit" id="submitBtn">충전하기</button>
+        </form>
+    </div>
+
+    <script>
+        // 폼 제출 처리
+        document.getElementById('depositChargeForm').addEventListener('submit', async function(e) {
+            e.preventDefault();
+            
+            const submitBtn = document.getElementById('submitBtn');
+            submitBtn.disabled = true;
+            submitBtn.textContent = '처리 중...';
+            
+            try {
+                const userCode = document.getElementById('userCode').value;
+                const amount = parseInt(document.getElementById('amount').value);
+                
+                if (!userCode || userCode.trim() === '') {
+                    alert('사용자 코드를 입력해주세요.');
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = '충전하기';
+                    return;
+                }
+                
+                if (!amount || amount <= 0) {
+                    alert('충전 금액을 입력해주세요.');
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = '충전하기';
+                    return;
+                }
+                
+                const formData = {
+                    amount: amount
+                };
+                
+                const response = await fetch('/api/orders/deposit/charge', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-User-Code': userCode
+                    },
+                    body: JSON.stringify(formData)
+                });
+                
+                if (response.redirected) {
+                    // 리다이렉트가 발생한 경우 (토스 결제)
+                    window.location.href = response.url;
+                } else if (response.ok) {
+                    const result = await response.json();
+                    alert('예치금 충전이 시작되었습니다!');
+                    console.log('예치금 충전 시작:', result);
+                } else {
+                    const error = await response.json();
+                    alert('예치금 충전 실패: ' + (error.message || '알 수 없는 오류'));
+                }
+            } catch (error) {
+                console.error('예치금 충전 실패:', error);
+                alert('예치금 충전 중 오류가 발생했습니다: ' + error.message);
+            } finally {
+                submitBtn.disabled = false;
+                submitBtn.textContent = '충전하기';
+            }
+        });
+    </script>
+</body>
+</html>
+

--- a/order/src/main/resources/templates/deposit-charge-success.html
+++ b/order/src/main/resources/templates/deposit-charge-success.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>예치금 충전 완료</title>
+</head>
+<body>
+    <div>
+        <h2>예치금 충전 완료</h2>
+        <p>충전 금액: ₩ <span th:text="${#numbers.formatInteger(amount, 0, 'COMMA')}"></span></p>
+        <p>예치금 충전이 완료되었습니다.</p>
+    </div>
+</body>
+</html>
+

--- a/order/src/main/resources/templates/deposit-charge.html
+++ b/order/src/main/resources/templates/deposit-charge.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>예치금 충전</title>
+    <script src="https://js.tosspayments.com/v2/standard"></script>
+</head>
+<body>
+    <div>
+        <h2>예치금 충전</h2>
+        <p>충전 금액: ₩ <span th:text="${#numbers.formatInteger(amount, 0, 'COMMA')}"></span></p>
+        
+        <div id="payment-method"></div>
+        <div id="agreement"></div>
+        
+        <button id="payment-button">충전하기</button>
+    </div>
+
+    <script th:inline="javascript">
+        async function main() {
+            const button = document.getElementById("payment-button");
+            
+            const amountValue = /*[[${amount}]]*/ 0;
+            const userCodeValue = /*[[${userCode}]]*/ '';
+            const clientKeyValue = /*[[${clientKey}]]*/ '';
+            const successUrlValue = /*[[${successUrl}]]*/ '';
+            const failUrlValue = /*[[${failUrl}]]*/ '';
+            const customerNameValue = /*[[${customerName}]]*/ '고객';
+            
+            if (!clientKeyValue || clientKeyValue.trim() === '') {
+                alert("클라이언트 키가 설정되지 않았습니다.");
+                return;
+            }
+            
+            if (amountValue <= 0) {
+                alert("충전 금액을 입력해주세요.");
+                return;
+            }
+            
+            if (!userCodeValue || userCodeValue.trim() === '') {
+                alert("사용자 코드가 설정되지 않았습니다.");
+                return;
+            }
+            
+            const amount = {
+                currency: "KRW",
+                value: amountValue,
+            };
+
+            try {
+                const tossPayments = TossPayments(clientKeyValue);
+                const widgets = tossPayments.widgets({customerKey: TossPayments.ANONYMOUS});
+                await widgets.setAmount(amount);
+
+                await widgets.renderPaymentMethods({
+                    selector: "#payment-method",
+                    variantKey: "DEFAULT",
+                });
+
+                await widgets.renderAgreement({selector: "#agreement", variantKey: "AGREEMENT"});
+
+                button.addEventListener("click", async function () {
+                    try {
+                        await widgets.requestPayment({
+                            orderId: "DEPOSIT-" + Date.now(),
+                            orderName: "예치금 충전",
+                            successUrl: successUrlValue,
+                            failUrl: failUrlValue,
+                            customerEmail: "customer@example.com",
+                            customerName: customerNameValue,
+                        });
+                    } catch (error) {
+                        console.error("결제 요청 실패:", error);
+                        alert("결제 요청 중 오류가 발생했습니다: " + error.message);
+                    }
+                });
+            } catch (error) {
+                console.error("위젯 초기화 실패:", error);
+                alert("결제 위젯 초기화 중 오류가 발생했습니다: " + error.message);
+            }
+        }
+
+        main();
+    </script>
+</body>
+</html>
+

--- a/payment/src/main/java/com/ll/payment/payment/controller/PaymentController.java
+++ b/payment/src/main/java/com/ll/payment/payment/controller/PaymentController.java
@@ -42,4 +42,12 @@ public class PaymentController {
         return BaseResponse.ok(result);
     }
 
+    @PostMapping("/deposit/charge")
+    public ResponseEntity<BaseResponse<Payment>> depositChargeWithToss(
+            @RequestBody PaymentRequest request
+    ) {
+        Payment payment = paymentService.depositChargeWithToss(request);
+        return BaseResponse.ok(payment);
+    }
+
 }

--- a/payment/src/main/java/com/ll/payment/payment/service/PaymentService.java
+++ b/payment/src/main/java/com/ll/payment/payment/service/PaymentService.java
@@ -13,4 +13,7 @@ public interface PaymentService {
 
     Payment refundPayment(PaymentRefundRequest request);
 
+    // 예치금 충전용 토스 결제 (일반 토스 결제 코드 재사용)
+    Payment depositChargeWithToss(PaymentRequest request);
+
 }

--- a/payment/src/main/java/com/ll/payment/payment/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/ll/payment/payment/service/PaymentServiceImpl.java
@@ -37,4 +37,22 @@ public class PaymentServiceImpl implements PaymentService {
         return paymentRefundService.refundPayment(request);
     }
 
+    @Override
+    public Payment depositChargeWithToss(PaymentRequest request) {
+        // 일반 토스 결제 코드 재사용 (CHARGE 상태로 결제)
+        Payment payment = tossPaymentService.tossPayment(request, PaymentStatus.CHARGE);
+        
+        // 결제 성공 후 예치금 충전
+        String chargeReferenceCode = "CHARGE-" + (request.orderId() != null ? request.orderId() : "DEPOSIT") + "-" + System.currentTimeMillis();
+        
+        depositPaymentService.chargeDepositAfterToss(
+                request.buyerCode(),
+                request.paidAmount(),
+                chargeReferenceCode
+        );
+        
+        log.debug("예치금 충전 완료 - buyerCode: {}, amount: {}", request.buyerCode(), request.paidAmount());
+        return payment;
+    }
+
 }

--- a/payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentService.java
+++ b/payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentService.java
@@ -9,5 +9,8 @@ public interface DepositPaymentService {
     PaymentProcessResult depositPayment(PaymentRequest payment);
 
     Payment completeDepositPayment(PaymentRequest payment, int amount);
+
+    // 토스 결제 완료 후 예치금 충전
+    void chargeDepositAfterToss(String buyerCode, int amount, String referenceCode);
 }
 

--- a/payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentServiceImpl.java
+++ b/payment/src/main/java/com/ll/payment/payment/service/deposit/DepositPaymentServiceImpl.java
@@ -153,6 +153,16 @@ public class DepositPaymentServiceImpl implements DepositPaymentService {
         return depositPayment;
     }
 
+    @Override
+    @Transactional
+    public void chargeDepositAfterToss(String buyerCode, int amount, String referenceCode) {
+        depositService.chargeDeposit(
+                buyerCode,
+                new DepositTransactionRequest((long) amount, referenceCode)
+        );
+        log.debug("토스 결제 후 예치금 충전 완료 - buyerCode: {}, amount: {}", buyerCode, amount);
+    }
+
     private String createReferenceCode(Long orderId) {
         return "ORDER-" + orderId + "-" + System.currentTimeMillis();
     }


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 예치금 충전 로직추가 

🔗 관련 이슈
---
- 관련 이슈 번호: #235

📋 요구 사항과 구현 내용
---
- 예치금 충전용 UI 구현
- 예치금 충전 로직 추가 구현

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. 예치금 충전용 전체 플로우 추가 (Order ↔ Payment 연동) 
 - OrderService / OrderServiceImpl에 `completeDepositChargeWithKey` 신설, 토스 결제 승인 후 예치금 충전을 하나의 트랜잭션 흐름으로 처리 
 - 예치금 충전 전용 Order 생성(`OrderType.ONLINE`, 상태 COMPLETED 변경) 및 `OrderHistoryEntity.createPaymentSuccessHistory`로 히스토리 기록 
 - `PaymentServiceClient.requestDepositChargeWithToss` 추가, payment 서비스 `/api/payments/deposit/charge` 호출로 토스 승인 + 예치금 충전 연동 

2. Payment 서비스 예치금 충전 로직 추가 
 - `PaymentController`에 `/payments/deposit/charge` POST 엔드포인트 추가, `PaymentService.depositChargeWithToss` 위임 
 - `PaymentService`/Impl에 `depositChargeWithToss` 구현: `tossPaymentService.tossPayment(..., PaymentStatus.CHARGE)` 재사용 후 예치금 충전 수행 
 - `DepositPaymentService`/Impl에 `chargeDepositAfterToss` 추가, `depositService.chargeDeposit` 호출 및 로그 기록 

3. 예치금 충전용 토스 결제 API 클라이언트 및 Resilience 처리 
 - `DepositServiceClient` 신규 추가: `/api/deposits/charge` 호출, Resilience4j CircuitBreaker + Retry 및 Fallback에서 `BaseException` 변환 
 - `PaymentServiceClient`에 `requestTossPaymentForCharge`, `requestDepositChargeWithToss` 및 각 Fallback 메서드 추가, 예치금 충전용 토스 플로우 분리 

4. 예치금 충전 웹/REST 엔드포인트 및 화면 추가 
 - `OrderController`에 `/deposit/charge` 시작, 성공(`/deposit/charge/success`), 실패(`/deposit/charge/fail`) 엔드포인트 추가 및 Swagger 인터페이스에 문서화 
 - `PaymentViewController`에 예치금 충전 폼, 토스 결제 페이지, 성공/실패 페이지 뷰 매핑 추가 및 `HttpSession`으로 `depositChargeUserCode` 관리 
 - Thymeleaf 템플릿 `deposit-charge-form.html`, `deposit-charge.html`, `deposit-charge-success.html`, `deposit-charge-fail.html` 추가 및 토스 위젯 연동·에러/성공 UI 구현
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [OrderController.depositChargeFail 리다이렉트 파라미터명 불일치로 인한 오류 정보 손실]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `OrderController.depositChargeFail`는 `errorMessage` 파라미터를 사용하지만, 리다이렉트 URL에서는 `error` 쿼리 파라미터를 사용하는 다른 엔드포인트(`depositChargeSuccess`)와 형식이 다르게 설계되어 있어, 실패 콜백에서 전달된 에러 메시지가 최종 실패 페이지까지 일관되게 전달되지 않을 수 있다.
 - 결과: 토스 실패 콜백(`/deposit/charge/fail`) → 뷰 컨트롤러(`/deposit/charge/fail-page`) 흐름에서 에러 메시지가 누락되거나 잘못된 키로 전달되어, 사용자가 실제 실패 사유를 확인하지 못할 수 있다.
 - 위험성: 결제/충전 실패 원인이 사용자 및 운영자에게 정확히 노출되지 않아 CS 증가 및 장애 원인 파악 지연으로 이어질 수 있다.

2. [OrderController.depositChargeSuccess의 세션 userCode 의존 로직으로 인한 예외 및 결제/충전 불일치 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `depositChargeSuccess`에서 예치금 충전 처리 시 `HttpSession`에 저장된 `"depositChargeUserCode"`를 필수로 사용하며, 세션 만료 또는 브라우저/디바이스 변경 시 `userCode`가 없으면 `IllegalArgumentException`을 발생시킨다.
 - 결과: 결제는 토스 측에서 성공했음에도 세션 상태에 따라 서버 측 예치금 충전 처리(`completeDepositChargeWithKey`)가 수행되지 않고 실패 페이지로 리다이렉트될 수 있다.
 - 위험성: 실제로 결제는 완료되었는데 예치금이 충전되지 않는 결제-충전 상태 불일치가 발생할 수 있고, 이는 직접적인 금전/정산 이슈로 이어질 수 있다.

3. [judgment 불가 – 토스 orderId 일관성 및 중복 관리]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 잠정적 문제 가능성
 - 원인: `deposit-charge.html`에서 `widgets.requestPayment` 호출 시 `orderId`를 `"DEPOSIT-" + Date.now()`로 생성하고, `OrderServiceImpl.completeDepositChargeWithKey`에서는 콜백 파라미터 `orderId`를 그대로 `tossOrderId`로 사용해 `OrderPaymentRequest`에 전달하지만, 토스 서버와의 계약(고유성, 재호출 시 일관성 등)에 대한 검증 정보가 diff에 없다.
 - 결과: 토스 측 요구사항(예: 동일 `orderId`에 대한 재승인, 중복 요청 처리 등)을 만족하지 못하는 경우, 특정 상황에서 승인 실패나 중복 승인 방지 로직과 충돌할 가능성이 있다.
 - 위험성: 계약 미준수 시 예외 발생 또는 일부 케이스에서 승인/정산 실패 가능성이 있으나, 토스 API 스펙 및 기존 구현이 diff에 없어 현재로서는 판단 불가이다.
<!-- AI-REVIEW:END -->