### PR TITLE
[refactor][246] 아웃박스 트랜잭션 분리 코드 수정

### DIFF
--- a/order/src/main/java/com/ll/order/domain/service/event/InventoryRollbackEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/InventoryRollbackEventOutboxService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -140,7 +139,7 @@ public class InventoryRollbackEventOutboxService {
     }
 
     // 이벤트를 Outbox에 저장 (PENDING 상태로 저장하여 스케줄러가 발행)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void saveToOutbox(String orderCode, String productCode, Integer quantity) {
         try {
             String referenceCode = Generators.timeBasedEpochGenerator().generate().toString();

--- a/order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -143,7 +142,7 @@ public class OrderEventOutboxService {
     }
 
     // 이벤트를 Outbox에 저장 (PENDING 상태로 저장하여 스케줄러가 발행)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void saveToOutbox(OrderEvent orderEvent, String orderCode, String orderItemCode) {
         try {
             OrderEventOutbox outbox = OrderEventOutbox.from(orderEvent, objectMapper);

--- a/order/src/main/java/com/ll/order/domain/service/event/PaymentRefundRequestEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/PaymentRefundRequestEventOutboxService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -117,7 +116,7 @@ public class PaymentRefundRequestEventOutboxService {
     }
 
     // 이벤트를 Outbox에 저장 (PENDING 상태로 저장하여 스케줄러가 발행)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void saveToOutbox(PaymentRefundRequestEvent event, String orderCode) {
         try {
             PaymentRefundEventOutbox outbox = PaymentRefundEventOutbox.from(event, orderCode, objectMapper);

--- a/order/src/main/java/com/ll/order/domain/service/event/RefundEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/RefundEventOutboxService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -119,7 +118,7 @@ public class RefundEventOutboxService {
     }
 
     // 이벤트를 Outbox에 저장 (PENDING 상태로 저장하여 스케줄러가 발행)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void saveToOutbox(RefundEvent refundEvent, String orderCode) {
         try {
             SettlementRefundEventOutbox outbox = SettlementRefundEventOutbox.from(refundEvent, orderCode, objectMapper);

--- a/products/src/test/resources/application-test.yml
+++ b/products/src/test/resources/application-test.yml
@@ -94,3 +94,7 @@ qdrant:
   port: 6334
   collection-name: products_test
 
+# Slack 설정 (테스트 환경에서는 Unknown 값 사용 - SlackWebhookService에서 Unknown일 경우 메시지 전송하지 않음)
+slack:
+  webhook-url: Unknown
+


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 트랜잭션 별도 생성 코드 삭제

🔗 관련 이슈
---
- 관련 이슈 번호: #246

📋 요구 사항과 구현 내용
---
- 아웃박스 저장 로직을 비즈니스 로직과 동일한 트랜잭션으로 묶이도록수정  

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Outbox 서비스 트랜잭션 전파 속성 제거 
 - `InventoryRollbackEventOutboxService.saveToOutbox`의 `@Transactional(propagation = Propagation.REQUIRES_NEW)` 를 기본 `@Transactional`로 변경 
 - `OrderEventOutboxService.saveToOutbox`의 트랜잭션 전파 설정을 제거하고 `@Transactional`만 사용하도록 수정 
 - `PaymentRefundRequestEventOutboxService.saveToOutbox`, `RefundEventOutboxService.saveToOutbox` 에서도 동일하게 `Propagation.REQUIRES_NEW` 제거 
 - 네 서비스 클래스 모두에서 `org.springframework.transaction.annotation.Propagation` import 삭제로 불필요한 의존성 정리 

2. 테스트 환경 Slack 설정 추가 
 - `products/src/test/resources/application-test.yml`에 `slack.webhook-url: Unknown` 설정 추가 
 - 주석으로 테스트 환경에서는 `Unknown` 값 사용 시 `SlackWebhookService`가 메시지를 전송하지 않음을 명시해 테스트 중 실제 Slack 호출을 방지
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. Outbox 저장 트랜잭션 전파 속성 변경으로 인한 Outbox 패턴 붕괴 가능성
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: 아래 4개 서비스의 `saveToOutbox(...)` 메서드에서 `@Transactional(propagation = Propagation.REQUIRES_NEW)`가 제거되고 단순 `@Transactional`로 변경됨.
 - order/src/main/java/com/ll/order/domain/service/event/InventoryRollbackEventOutboxService.java
 - order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
 - order/src/main/java/com/ll/order/domain/service/event/PaymentRefundRequestEventOutboxService.java
 - order/src/main/java/com/ll/order/domain/service/event/RefundEventOutboxService.java
 - 결과: 상위 트랜잭션과 동일한 트랜잭션 경계 안에서 Outbox 레코드가 저장되어, 상위 트랜잭션 롤백 시 Outbox도 같이 롤백됨. Outbox에서 발행해야 할 이벤트 자체가 DB에 남지 않을 수 있음.
 - 위험성: 주문/결제/재고/환불 관련 도메인 이벤트가 실제 비즈니스 상태와 불일치하게 발행되거나 아예 발행되지 않는 상황이 발생할 수 있어, 데이터 무결성 및 시스템 간 상태 동기화(마이크로서비스 간)에 중대한 오류를 유발할 가능성이 큼. 장애 재처리·재시도 로직(스케줄러 기반 Outbox 발행)에 치명적인 영향을 줄 수 있음.

2. [판단 불가] Slack 테스트 설정 변경에 따른 알림 누락 가능성
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: products/src/test/resources/application-test.yml 에 Slack 설정이 추가되며 `slack.webhook-url: Unknown` 값을 사용하도록 변경.
 - 파일: products/src/test/resources/application-test.yml
 ```yml
 slack:
 webhook-url: Unknown
 ```
 - 결과: diff 설명에 따르면 SlackWebhookService에서 `Unknown` 일 경우 메시지를 전송하지 않는다고 되어 있어, 테스트 환경에서 Slack 알림이 전혀 전송되지 않도록 동작할 가능성이 있음.
 - 위험성: 테스트 환경에서만 적용되는 설정이며 실제 코드 구현이 diff에 보이지 않아, 알림 누락이 실제로 치명적인지 여부는 판단 불가. 다만 장애/오류를 Slack으로 감지하는 테스트 시나리오가 있다면, 알림 미발송으로 인해 문제 조기 탐지가 안 될 수 있는 잠정적 위험이 존재함.
<!-- AI-REVIEW:END -->