### PR TITLE
[fix][250] Swagger 오류 수정

### DIFF
--- a/auth/src/main/java/com/ll/auth/config/SecurityConfig.java
+++ b/auth/src/main/java/com/ll/auth/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOriginPatterns(List.of("*")); // 추후 변경
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS","PATCH"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 

--- a/core/src/main/java/com/ll/core/config/swagger/SwaggerConfig.java
+++ b/core/src/main/java/com/ll/core/config/swagger/SwaggerConfig.java
@@ -56,7 +56,33 @@ public class SwaggerConfig {
                 target.setRequired(false);
                 target.setName("X-User-Code");
                 target.setDescription("사용자 고유 코드");
-                target.schema(new StringSchema().type("string").example("X-User-Code ex) 019a90ab-fcf3-7413-af08-7121cc99378b"));
+            }
+
+            operation.setParameters(original);
+
+            return operation;
+        };
+    }
+
+    @Bean
+    public OperationCustomizer hideUserCodeRole() {
+        return (operation, handlerMethod) -> {
+            List<Parameter> original = operation.getParameters();
+
+            if (original == null) {
+                original = new ArrayList<>();
+            }
+
+            Parameter target = original.stream()
+                    .filter(p -> "X-Role".equalsIgnoreCase(p.getName()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (target != null) {
+                target.in(ParameterIn.HEADER.toString());
+                target.setRequired(false);
+                target.setName("X-Role");
+                target.setDescription("사용자 권한 정보");
             }
 
             operation.setParameters(original);

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -92,7 +92,7 @@ spring:
               predicates:
                 - Path=/api/orders/**, /api/orders
                 - Method=POST, GET, PATCH, DELETE
-                - # - name: CSRFValidationFilter
+                # - name: CSRFValidationFilter
               filters:
                 - name: TokenAuthenticationFilter
               order: 2
@@ -109,7 +109,7 @@ spring:
               uri: http://localhost:8084
               predicates:
                 - Path=/api/users/**
-                - Method=POST, GET, PATCH, DELETE
+                - Method=POST, GET, PATCH, DELETE, PATCH
               filters:
                 - name: TokenAuthenticationFilter
                   # - name: CSRFValidationFilter


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Security 설정 변경
- SwaggerConfig X-Role 설정 변경

🔗 관련 이슈
---
- 관련 이슈 번호: #250

📋 요구 사항과 구현 내용
---
- Security 설정 변경
- SwaggerConfig X-Role 설정 변경

💬 TODO 리스트
---

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. CORS 설정에 PATCH 메서드 허용 추가 (`SecurityConfig`)
 - `corsConfigurationSource`에서 `setAllowedMethods` 목록에 `"PATCH"`를 추가해 CORS 요청에서 PATCH 메서드 허용
 - 향후 PATCH 기반 API 호출 시 브라우저 CORS 제약으로 인한 오류 가능성 완화

2. Swagger 요청 헤더 커스터마이징 확장 (`SwaggerConfig`)
 - 기존 `hideUserCodeHeader`에서 `X-User-Code` 파라미터 스키마 설정 제거 후, 파라미터 리스트 재설정 로직만 유지
 - 새로운 `hideUserCodeRole` `OperationCustomizer` 추가
 - `X-Role` 파라미터를 찾아 HEADER 타입으로 지정
 - 필수 아님(`required=false`), 이름 `X-Role`, 설명을 "사용자 권한 정보"로 설정

3. Gateway 라우팅 및 필터 설정 조정 (`application-local.yml`)
 - `/api/orders` 라우트의 `CSRFValidationFilter` 설정 라인을 주석 형태 정리(`- # - name` → `# - name`)하여 의도 명확화
 - `/api/users/**` 라우트의 `Method` 프레디킷에 `"PATCH"`를 중복 추가 (POST, GET, PATCH, DELETE, PATCH)하여 설정 오류 가능성 존재
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. SwaggerConfig.java: `hideUserCodeHeader` 로직 일부 삭제로 인한 스펙 누락 가능성

 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - `hideUserCodeHeader` 메서드에서 `target.schema(...)` 설정 라인이 제거되었고, 동일 기능을 대체하는 코드가 diff 내에 보이지 않는다.
 - 기존에는 `X-User-Code` 헤더에 대해 `StringSchema` 및 예시값이 정의되어 있었으나, 현재는 단순히 파라미터 검색·설정만 수행하고 스키마 정의를 하지 않는다.
 - 결과:
 - Swagger/OpenAPI 문서에서 `X-User-Code` 헤더의 타입 및 example 정보가 사라져 API 스펙이 불완전해질 수 있다.
 - 클라이언트가 문서를 기반으로 구현할 때 해당 헤더의 형식·예시를 확인할 수 없어 잘못된 값 전송 가능성이 높아진다.
 - 위험성:
 - 실제 런타임 오류는 아니지만, 문서-실제 구현 간 불일치로 인해 잘못된 요청이 증가하고, 인증/인가 관련 기능 오사용으로 이어질 수 있는 중대한 논리/운영 상 문제다.

 - 원인 코드:
 - core/src/main/java/com/ll/core/config/swagger/SwaggerConfig.java:
 ```java
 if (target != null) {
 target.in(ParameterIn.HEADER.toString());
 target.setRequired(false);
 target.setName("X-User-Code");
 target.setDescription("사용자 고유 코드");
 }

 operation.setParameters(original);
 ```

2. gateway `application-local.yml`: 중복된 PATCH Method 설정으로 인한 설정 품질 저하

 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - `/api/users/**` 라우트의 `Method` 프리디케이트에 `PATCH`가 중복 기재됨.
 - 결과:
 - Spring Cloud Gateway 입장에서는 동일 HTTP 메서드가 중복 정의되더라도 일반적으로 기능적 문제는 없지만, 설정 오타/복사 실수로 간주될 수 있다.
 - 위험성:
 - 현재 diff만 기준으로는 서비스 중단/무결성 훼손까지는 이어지지 않으나, 설정 관리 품질 저하와 오타 방치로 인한 추후 설정 오류 가능성을 높이는 잠재적 위험 요소다.
 - 원인 코드:
 - gateway/src/main/resources/application-local.yml:
 ```yaml
 - Path=/api/users/**
 - Method=POST, GET, PATCH, DELETE, PATCH
 ```
<!-- AI-REVIEW:END -->