### PR TITLE
[refactor][254] 주문 취소 가능 시간 설정 

### DIFF
--- a/order/src/main/java/com/ll/order/domain/exception/OrderErrorCode.java
+++ b/order/src/main/java/com/ll/order/domain/exception/OrderErrorCode.java
@@ -21,6 +21,7 @@ public enum OrderErrorCode implements BaseErrorCode {
     // 409 — 충돌 발생
     ORDER_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 주문입니다."),
     INVALID_ORDER_STATUS_TRANSITION(HttpStatus.CONFLICT, "해당 상태로 전환할 수 없습니다."),
+    ORDER_CANCEL_NOT_ALLOWED_WITHIN_GRACE_PERIOD(HttpStatus.CONFLICT, "주문 완료 후 10분 이내에는 취소할 수 없습니다."),
 
     // 422 — 처리 불가능한 엔티티
     INSUFFICIENT_INVENTORY(HttpStatus.UNPROCESSABLE_ENTITY, "재고가 부족합니다."),

--- a/order/src/main/java/com/ll/order/domain/repository/OrderEventOutboxRepository.java
+++ b/order/src/main/java/com/ll/order/domain/repository/OrderEventOutboxRepository.java
@@ -15,5 +15,9 @@ public interface OrderEventOutboxRepository extends JpaRepository<OrderEventOutb
             @Param("status") OutboxStatus status,
             @Param("maxRetryCount") Integer maxRetryCount
     );
+
+    // outbox의 referenceCode는 저장될 때 orderCode로 저장을 함
+    @Query("SELECT o FROM OrderEventOutbox o WHERE o.referenceCode = :referenceCode")
+    List<OrderEventOutbox> findByReferenceCode(@Param("referenceCode") String referenceCode);
 }
 

--- a/order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -156,6 +157,24 @@ public class OrderEventOutboxService {
                     orderCode, orderItemCode, orderEvent.referenceCode(), e.getMessage(), e);
             // Outbox 저장 실패는 로그만 남기고 계속 진행 (수동 처리 필요)
         }
+    }
+
+    public boolean isCancelable(String orderCode) {
+        List<OrderEventOutbox> outboxes = orderEventOutboxRepository.findByReferenceCode(orderCode);
+
+        if (outboxes.isEmpty()) {
+            log.warn("주문 이벤트 Outbox가 없어 취소를 막습니다. orderCode: {}", orderCode);
+            return false; // 또는 예외 던지기
+        }
+
+        // 가장 이른 생성 시점을 기준으로 10분 보호 구간을 둔다
+        LocalDateTime earliestCreatedAt = outboxes.stream()
+                .map(OrderEventOutbox::getCreatedAt)
+                .min(LocalDateTime::compareTo)
+                .orElse(LocalDateTime.now());
+
+                // 아웃박스 생성 시점부터 10분 이내인지 여부를 확인
+        return LocalDateTime.now().isAfter(earliestCreatedAt.plusMinutes(10));
     }
 }
 

--- a/order/src/main/java/com/ll/order/domain/service/event/OrderEventService.java
+++ b/order/src/main/java/com/ll/order/domain/service/event/OrderEventService.java
@@ -32,5 +32,9 @@ public class OrderEventService {
             orderEventOutboxService.saveToOutbox(orderEvent, order.getCode(), orderItem.getCode());
         }
     }
+
+    public boolean isCancelable(String orderCode) {
+        return orderEventOutboxService.isCancelable(orderCode);
+    }
 }
 

--- a/order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
+++ b/order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
@@ -177,6 +177,11 @@ public class OrderServiceImpl implements OrderService {
         String buyerCode = order.getBuyerCode();
 
         if (order.getOrderStatus() == OrderStatus.COMPLETED) {
+            // 주문 완료 Outbox 생성 시점 기준으로 10분 이내에는 취소 불가
+            if (!orderEventService.isCancelable(order.getCode())) {
+                log.warn("주문 완료 후 10분 이내에는 취소할 수 없습니다. orderCode: {}", order.getCode());
+                throw new BaseException(OrderErrorCode.ORDER_CANCEL_NOT_ALLOWED_WITHIN_GRACE_PERIOD);
+            }
             try {
                 PaymentRefundRequestEvent refundRequestEvent = PaymentRefundRequestEvent.from(
                         order.getId(),


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- 주문 취소는 생성 이후 10분 이후로

🔗 관련 이슈
---
- 관련 이슈 번호: #254

📋 요구 사항과 구현 내용
---
- 주문 아웃박스 생성 시간 확인 후 10분 이내 취소 요청인지 확인

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. 주문 완료 후 일정 시간 내 취소 제한 기능 추가 
 - `OrderErrorCode`에 `ORDER_CANCEL_NOT_ALLOWED_WITHIN_GRACE_PERIOD`(409) 추가, 메시지: "주문 완료 후 10분 이내에는 취소할 수 없습니다." 
 - `OrderServiceImpl.handleOrderCancel`에서 `OrderStatus.COMPLETED`일 때 `orderEventService.isCancelable(order.getCode())` 검사 후, 10분 이내면 로그 남기고 `BaseException`으로 위 에러코드 발생 

2. Outbox 기반 주문 취소 가능 여부 판별 로직 추가 
 - `OrderEventOutboxRepository`에 `findByReferenceCode(String referenceCode)` JPA 쿼리 메서드 추가 (`referenceCode`는 저장 시 `orderCode` 사용) 
 - `OrderEventOutboxService.isCancelable(String orderCode)`에서 해당 `orderCode`의 `OrderEventOutbox` 목록 조회 
 - 결과가 비어 있으면 경고 로그 후 취소 불가(`false`) 반환 
 - 존재할 경우 가장 이른 `createdAt` 기준으로 10분 보호 구간 계산 후, 현재 시간이 `earliestCreatedAt.plusMinutes(10)` 이후인지 여부로 취소 가능 여부 반환 
 - `OrderEventService`에 `isCancelable(String orderCode)` 위임 메서드 추가, 서비스 계층에서 Outbox 기반 취소 가능 여부 사용 가능하도록 함
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [isCancelable 로직의 outbox 미존재 처리로 인한 정상 주문 취소 불가 및 서비스 장애 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - OrderEventOutboxService.isCancelable에서 해당 orderCode의 OrderEventOutbox가 하나도 없으면 경고 로그 후 무조건 false를 반환함.
 - OrderServiceImpl.handleOrderCancel에서 isCancelable이 false인 경우 BaseException(OrderErrorCode.ORDER_CANCEL_NOT_ALLOWED_WITHIN_GRACE_PERIOD)를 던져 취소를 막음.
 - 파일명: order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
 ```java
 public boolean isCancelable(String orderCode) {
 List<OrderEventOutbox> outboxes = orderEventOutboxRepository.findByReferenceCode(orderCode);

 if (outboxes.isEmpty()) {
 log.warn("주문 이벤트 Outbox가 없어 취소를 막습니다. orderCode: {}", orderCode);
 return false; // 또는 예외 던지기
 }
 ```
 - 파일명: order/src/main/java/com/ll/order/domain/service/order/OrderServiceImpl.java
 ```java
 if (order.getOrderStatus() == OrderStatus.COMPLETED) {
 // 주문 완료 Outbox 생성 시점 기준으로 10분 이내에는 취소 불가
 if (!orderEventService.isCancelable(order.getCode())) {
 log.warn("주문 완료 후 10분 이내에는 취소할 수 없습니다. orderCode: {}", order.getCode());
 throw new BaseException(OrderErrorCode.ORDER_CANCEL_NOT_ALLOWED_WITHIN_GRACE_PERIOD);
 }
 try {
 ```
 - 결과:
 - Outbox 데이터가 유실되거나, 아직 쓰이지 않았거나, 다른 사유로 비어 있는 경우에도 무조건 “10분 이내 취소 불가” 예외가 발생해 정상적으로 취소 가능해야 할 주문이 영구적으로 취소되지 않을 수 있음.
 - 위험성:
 - 운영 중 Outbox 테이블 장애/정리/지연 등의 이슈가 발생하면 주문 취소 기능이 광범위하게 막히고, 이는 서비스 장애 및 고객 CS 폭증으로 이어질 수 있음. 또한 Outbox는 보통 비동기 처리 보조 수단인데, 그 존재 여부를 취소 허용 여부의 절대 조건으로 사용해 비즈니스 로직이 인프라 상태에 과도하게 종속되는 구조적 위험이 있음.

2. [isCancelable의 LocalDateTime.now() 기반 비교로 인한 테스트 및 재현 불가, 잠재적 시간 관련 논리 문제]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - isCancelable에서 보호 구간 판단 시 LocalDateTime.now()를 직접 호출하여 earliestCreatedAt.plusMinutes(10)와 비교함.
 - 파일명: order/src/main/java/com/ll/order/domain/service/event/OrderEventOutboxService.java
 ```java
 LocalDateTime earliestCreatedAt = outboxes.stream()
 .map(OrderEventOutbox::getCreatedAt)
 .min(LocalDateTime::compareTo)
 .orElse(LocalDateTime.now());

 // 아웃박스 생성 시점부터 10분 이내인지 여부를 확인
 return LocalDateTime.now().isAfter(earliestCreatedAt.plusMinutes(10));
 ```
 - 결과:
 - 시스템 시간 변경(서버 시간 드리프트, NTP 보정, 타임존 설정 오류 등) 시 보호 구간 계산이 실제 경과 시간과 어긋날 수 있고, 테스트 코드에서 시간을 제어하기 어려워 재현/검증이 곤란해짐.
 - 위험성:
 - 배포 환경이나 서버 간 시간 차이로 인해 어떤 서버에서는 취소 가능, 다른 서버에서는 불가와 같은 비일관적인 동작이 발생할 수 있고, 이는 데이터 정합성과 사용자 경험에 중대한 문제를 야기할 수 있음.

3. [잠정적 문제 가능성 – referenceCode를 orderCode로 사용하는 쿼리의 정확성 불명]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인:
 - OrderEventOutboxRepository.findByReferenceCode에서 referenceCode 필드를 orderCode로 저장한다고 주석에 명시하고 이를 기반으로 조회하지만, diff 상으로 엔티티 매핑 및 실제 저장 로직 전체 맥락은 보이지 않음.
 - 파일명: order/src/main/java/com/ll/order/domain/repository/OrderEventOutboxRepository.java
 ```java
 // outbox의 referenceCode는 저장될 때 orderCode로 저장을 함
 @Query("SELECT o FROM OrderEventOutbox o WHERE o.referenceCode = :referenceCode")
 List<OrderEventOutbox> findByReferenceCode(@Param("referenceCode") String referenceCode);
 ```
 - 결과:
 - referenceCode에 다른 값(예: orderItemCode, 외부 연동 키 등)이 저장되거나 멀티 키 전략을 사용하는 경우, 해당 쿼리가 의도한 주문 이벤트를 제대로 찾지 못해 isCancelable 판단이 잘못될 수 있음.
 - 위험성:
 - 현재 diff 만으로 엔티티와 저장 로직을 확인할 수 없어 ‘판단 불가’지만, 만약 매핑이 어긋나 있다면 보호 구간 계산 전체가 잘못된 데이터에 기반하게 되어 취소 허용/차단 로직이 비즈니스 요구와 다르게 동작할 위험이 있음.
<!-- AI-REVIEW:END -->