### PR TITLE
[chore][257] Kafka Topic init 수정

### DIFF
--- a/infra/scripts/00-env.sh
+++ b/infra/scripts/00-env.sh
@@ -26,12 +26,12 @@ declare -A DEFAULT_TOPICS=(
   ["user-create-event.dlq"]=1
   ["order-event"]=1
   ["order-event.dlq"]=1
-  ["refund-event"]=1
-  ["refund-event.dlq"]=1
   ["inventory-event"]=1
   ["inventory-event.dlq"]=1
   ["product-event"]=1
   ["product-event.dlq"]=1
+  ["payment-refund-notification-event"]=1
+  ["payment-refund-notification-event.dlq"]=1
 )
 
 # 시간 포맷

--- a/infra/scripts/00-env.sh
+++ b/infra/scripts/00-env.sh
@@ -30,6 +30,8 @@ declare -A DEFAULT_TOPICS=(
   ["inventory-event.dlq"]=1
   ["product-event"]=1
   ["product-event.dlq"]=1
+  ["payment-refund-request-event"]=1
+  ["payment-refund-request-event.dlq"]=1
   ["payment-refund-notification-event"]=1
   ["payment-refund-notification-event.dlq"]=1
 )


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Kafka Topic init 수정

🔗 관련 이슈
---
- 관련 이슈 번호: #257

📋 요구 사항과 구현 내용
---
- Kafka Topic init 수정

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등






<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Kafka 토픽 구성 변경 
 - `refund-event`, `refund-event.dlq` 토픽을 `DEFAULT_TOPICS` 목록에서 제거함 
 - `payment-refund-request-event`, `payment-refund-request-event.dlq` 신규 토픽을 추가해 환불 요청 이벤트용 채널을 분리함 
 - `payment-refund-notification-event`, `payment-refund-notification-event.dlq` 신규 토픽을 추가해 환불 결과 알림용 채널을 분리함
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [기존 refund-event 토픽 제거에 따른 프로듀서/컨슈머 불일치 가능성]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: infra/scripts/00-env.sh 에서 DEFAULT_TOPICS 배열에서 "refund-event", "refund-event.dlq" 항목이 제거되고, 대신 다른 이름의 refund 관련 토픽들이 추가됨.
 - 결과: 애플리케이션의 프로듀서/컨슈머 코드, 인프라 템플릿, 설정 등이 여전히 "refund-event" / "refund-event.dlq" 토픽을 사용 중이라면, 해당 토픽이 더 이상 생성되지 않아 메시지 전송/소비가 실패하거나 재시도 무한 루프가 발생할 수 있음.
 - 위험성: 환불 관련 이벤트가 유실되거나 처리되지 않아 비즈니스 로직 오류, 정산/환불 금액 불일치, 고객 환불 지연 등 데이터 무결성과 서비스 신뢰도에 직접적인 영향을 줄 수 있음.

2. [새 payment-refund-* 토픽의 사용 코드 미정의/미설정 가능성 (잠정적 문제 가능성)]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: infra/scripts/00-env.sh 에 "payment-refund-request-event", "payment-refund-notification-event" 및 각 .dlq 토픽이 새로 추가되었으나, 이 토픽을 실제로 사용하고 설정하는 애플리케이션 코드/인프라 정의는 diff에서 확인 불가.
 - 결과: 애플리케이션이 여전히 기존 토픽명을 사용하거나, 새로운 토픽명을 오타/불일치 상태로 참조할 경우 런타임 시 메시지 송수신 실패가 발생할 수 있음.
 - 위험성: 현재 diff만으로는 실제 오류 발생 여부를 판단 불가하나, 이벤트 기반 아키텍처에서 토픽명 불일치는 즉시 장애(메시지 유실·미처리)로 이어질 수 있는 잠재적 고위험 요소임.
<!-- AI-REVIEW:END -->