### PR TITLE
[style][261]

### DIFF
--- a/payment/src/main/java/com/ll/payment/settlement/batch/config/SettlementJobConfiguration.java
+++ b/payment/src/main/java/com/ll/payment/settlement/batch/config/SettlementJobConfiguration.java
@@ -1,6 +1,6 @@
 package com.ll.payment.settlement.batch.config;
 
-import com.ll.payment.settlement.batch.listener.SettlementBatchJobLogger;
+import com.ll.payment.settlement.batch.listener.SettlementBatchJobListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -19,10 +19,10 @@ public class SettlementJobConfiguration {
     public Job settlementsJob(
             JobRepository jobRepository,
             @Qualifier("settlementStep") Step settlementStep,
-            SettlementBatchJobLogger logger
+            SettlementBatchJobListener listener
     ) {
         return new JobBuilder("settlementsJob", jobRepository)
-                .listener(logger)
+                .listener(listener)
                 .start(settlementStep)
                 .build();
     }

--- a/payment/src/main/java/com/ll/payment/settlement/batch/config/SettlementStepConfiguration.java
+++ b/payment/src/main/java/com/ll/payment/settlement/batch/config/SettlementStepConfiguration.java
@@ -1,7 +1,7 @@
 package com.ll.payment.settlement.batch.config;
 
 import com.ll.core.model.exception.BaseException;
-import com.ll.payment.settlement.batch.listener.SettlementBatchStepLogger;
+import com.ll.payment.settlement.batch.listener.SettlementBatchStepListener;
 import com.ll.payment.settlement.batch.listener.SettlementSkipListener;
 import com.ll.payment.settlement.batch.processor.ValidateDepositProcessor;
 import com.ll.payment.settlement.batch.processor.SettlementSuccessProcessor;
@@ -38,7 +38,7 @@ public class SettlementStepConfiguration {
             @Qualifier("validateDepositProcessor") ValidateDepositProcessor validateDepositProcessor,
             @Qualifier("settlementSuccessProcessor") SettlementSuccessProcessor settlementSuccessProcessor,
             @Qualifier("settlementJdbcWriter") JdbcBatchItemWriter<Settlement> settlementJdbcWriter,
-            SettlementBatchStepLogger logger,
+            SettlementBatchStepListener listener,
             SettlementSkipListener skipListener
     ) {
         return new StepBuilder("settlementStep", jobRepository)
@@ -46,7 +46,7 @@ public class SettlementStepConfiguration {
                 .reader(settlementReader)
                 .processor(settlementProcessor(validateDepositProcessor, settlementSuccessProcessor))
                 .writer(settlementJdbcWriter)
-                .listener(logger)
+                .listener(listener)
                 .faultTolerant()
                 .skip(BaseException.class)
                 .skipLimit(SKIP_LIMIT)

--- a/payment/src/main/java/com/ll/payment/settlement/batch/listener/SettlementBatchJobListener.java
+++ b/payment/src/main/java/com/ll/payment/settlement/batch/listener/SettlementBatchJobListener.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class SettlementBatchJobLogger implements JobExecutionListener {
+public class SettlementBatchJobListener implements JobExecutionListener {
 
     private long start;
 

--- a/payment/src/main/java/com/ll/payment/settlement/batch/listener/SettlementBatchStepListener.java
+++ b/payment/src/main/java/com/ll/payment/settlement/batch/listener/SettlementBatchStepListener.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class SettlementBatchStepLogger implements StepExecutionListener {
+public class SettlementBatchStepListener implements StepExecutionListener {
     private long start;
     private final SettlementErrorCapture errorCapture;
     private final SettlementRepository settlementRepository;


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
---
- Settlement Listener 이름 변경

🔗 관련 이슈
---
- 관련 이슈 번호: #261

📋 요구 사항과 구현 내용
---
- Settlement Listener 이름 변경

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Settlement 배치 Job 리스너 명칭 정리 
 - `SettlementBatchJobLogger` 클래스 파일을 `SettlementBatchJobListener`로 rename 
 - 클래스 선언부를 `SettlementBatchJobListener`로 변경 
 - `SettlementJobConfiguration`에서 의존성 타입 및 파라미터명을 `SettlementBatchJobListener listener`로 변경 
 - `JobBuilder`에 등록되는 리스너를 `logger`에서 `listener`로 변경

2. Settlement 배치 Step 리스너 명칭 정리 
 - `SettlementBatchStepLogger` 클래스 파일을 `SettlementBatchStepListener`로 rename 
 - 클래스 선언부를 `SettlementBatchStepListener`로 변경 
 - `SettlementStepConfiguration`에서 의존성 타입 및 파라미터명을 `SettlementBatchStepListener listener`로 변경 
 - `StepBuilder`에 등록되는 리스너를 `logger`에서 `listener`로 변경
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. 클래스명 변경에 따른 Spring Bean 주입 실패 가능성
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `SettlementBatchJobLogger` → `SettlementBatchJobListener`, `SettlementBatchStepLogger` → `SettlementBatchStepListener`로 클래스명이 변경되었고, 이를 생성자/메서드 인자 타입에서도 교체했으나, 다른 곳(예: 설정, XML, 직접 `@Qualifier` 이름 사용 등)에서 이전 클래스명을 참조하고 있을 수 있음.
 - 결과: 만약 다른 Bean 정의/참조가 여전히 `SettlementBatchJobLogger` 또는 `SettlementBatchStepLogger`를 사용하고 있다면 애플리케이션 기동 시점에 `NoSuchBeanDefinitionException` 또는 `UnsatisfiedDependencyException`으로 인해 배치 실행 자체가 불가능해질 수 있음.
 - 위험성: diff에서 보이는 범위 내에서는 rename과 참조 변경이 일치해 컴파일 오류는 없으나, 프로젝트 전체에서 이전 타입명을 참조하는 다른 코드가 존재할 경우 서비스(배치 잡) 기동 실패로 이어질 수 있음. (diff 외 코드 문맥이 보이지 않아 “판단 불가” 범주의 잠정적 문제 가능성임)

 잠정적 문제 가능성:
 - SettlementJobConfiguration.java, SettlementStepConfiguration.java, SettlementBatchJobListener.java, SettlementBatchStepListener.java 외 파일에서 `SettlementBatchJobLogger`, `SettlementBatchStepLogger`를 타입 또는 Bean 이름으로 참조하고 있는지 추가 확인 필요.
<!-- AI-REVIEW:END -->