### PR TITLE
[docs][263] swagger 수정

### DIFF
--- a/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
+++ b/products/src/main/java/com/ll/products/domain/product/controller/ProductController.java
@@ -4,11 +4,11 @@ import com.ll.core.model.response.BaseResponse;
 import com.ll.products.domain.history.service.HistoryFacadeService;
 import com.ll.products.domain.product.controller.swagger.*;
 import com.ll.products.domain.product.model.dto.request.ProductUpdateInventoryRequest;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -73,7 +73,7 @@ public class ProductController {
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) ProductStatus status,
             @RequestParam(required = false) String name,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject() @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<ProductListResponse> response = productService.getProducts(
                 sellerCode, categoryId, status, name, pageable


### PR DESCRIPTION
📝 PR 제목 규칙 : [타입][이슈번호] PR 내용

✨ 작업 설명
--- swagger 상품 목록 조회 API page 중복 입력 제거
- 핵심 변경 사항 요약
--- swagger 상품 목록 조회 API page 중복 입력 제거
🔗 관련 이슈
--- [product][docs] swagger 수정
- 관련 이슈 번호: #263

📋 요구 사항과 구현 내용
--- swagger 상품 목록 조회 API page 중복 입력 제거
- 자세한 구현내용 1
- 자세한 구현내용 2

💬 TODO 리스트
---
- [ ] 내용 1
- [ ] 내용 2

🧠 고려사항
---
- 고민한 점
- 트러블슈팅
- 설계 판단
- 인사이트 등




<!-- AI-GENERATOR:START -->
⚙️ AI 생성 요약
---
1. Swagger/OpenAPI 파라미터 애노테이션 변경 
 - `io.swagger.v3.oas.annotations.Parameter` import 제거 
 - `org.springdoc.core.annotations.ParameterObject` import 추가 

2. Pageable Swagger 문서 명시화 
 - `getProducts` 메서드의 `Pageable pageable` 파라미터에 `@ParameterObject` 애노테이션 추가 
 - 기존 `@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)` 설정은 유지하며, Pageable에 대한 Swagger 문서 생성 개선
<!-- AI-GENERATOR:END -->
<!-- AI-REVIEW:START -->
🛠️ AI 코드 리뷰
---
1. [springdoc-openapi용 애노테이션 변경으로 인한 문서/요청 바인딩 문제]
 - [ ] 해결할 필요 있는 문제인지 여부: (예/아니오)
 - 원인: `io.swagger.v3.oas.annotations.Parameter` 사용을 제거하고, `Pageable` 파라미터에 `org.springdoc.core.annotations.ParameterObject` 애노테이션을 추가함.
 - 결과: OpenAPI 스펙 상 `Pageable` 관련 쿼리 파라미터가 잘못 표현되거나 누락될 수 있으며, 도구 기반 클라이언트에서 페이지 네이션 요청이 예상과 다르게 동작할 수 있음.
 - 위험성: 잘못된 스펙을 신뢰하는 외부/내부 클라이언트가 잘못된 파라미터를 호출해 응답 오류·데이터 조회 문제를 겪을 수 있어, API 연동 관점에서 치명적 문제가 될 수 있음.

잠정적 문제 가능성
 - [Pageable 바인딩/동작 영향 여부 판단 불가]
 - 원인: diff 상에서는 `@ParameterObject` 추가 외에 컨트롤러 로직, 스프링/ springdoc 설정, 의존성 버전 등이 보이지 않아 런타임 바인딩 영향 여부 확인 불가.
 - 결과: 특정 springdoc 버전·설정 조합에서만 발생하는 이슈(예: 파라미터 이름/기본값 처리 변화 등)가 있는지 판단할 수 없음.
 - 위험성: 문서화 용도의 애노테이션으로 보이며 컴파일 에러는 없으나, 실제 실행 환경과 설정을 알 수 없어 동작상 부작용 여부는 단정할 수 없음.
<!-- AI-REVIEW:END -->